### PR TITLE
ci(release): route the release cut through a PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,13 @@
 name: ci
 
+# workflow_dispatch lets cut-release trigger checks on its release branch —
+# PRs created with GITHUB_TOKEN don't fire pull_request workflows, and the
+# branch-protection required checks must still report on the head SHA.
 on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -19,6 +19,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 concurrency: cut-release
 
@@ -56,4 +57,7 @@ jobs:
             --base main --head "release/v${ver}" \
             --title "chore(release): v${ver}" \
             --body "$body"
+          # bot-created PRs don't fire pull_request workflows; run the
+          # required checks on the release branch explicitly
+          gh workflow run ci.yml --ref "release/v${ver}"
           echo "release PR for v${ver} opened — merge it to tag + publish" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -2,8 +2,12 @@ name: cut-release
 
 # Cut a release from the Actions tab: computes the next vX.Y.Z from
 # Conventional Commits (git-cliff), bumps Cargo.toml, regenerates
-# CHANGELOG.md, commits, tags, pushes, and dispatches the release build.
-# Same code path as a local cut — both run scripts/release.sh.
+# CHANGELOG.md, and opens a release PR. Merging that PR (the authorized,
+# branch-protection-compliant step) triggers tag-release.yml, which tags
+# the merged commit and dispatches the build.
+#
+# Needs "Allow GitHub Actions to create and approve pull requests" enabled
+# under Settings -> Actions -> General.
 on:
   workflow_dispatch:
     inputs:
@@ -14,7 +18,7 @@ on:
 
 permissions:
   contents: write
-  actions: write
+  pull-requests: write
 
 concurrency: cut-release
 
@@ -30,18 +34,26 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: git-cliff
-      - name: Cut release commit + tag
+      - name: Cut release commit on a release branch
         env:
           VERSION: ${{ inputs.version }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          ./scripts/release.sh $VERSION
-      - name: Push and dispatch the build
+          ver="${VERSION:-$(git-cliff --bumped-version)}"
+          ver="${ver#v}"
+          git checkout -b "release/v${ver}"
+          ./scripts/release.sh --no-tag "$ver"
+          echo "ver=${ver}" >> "$GITHUB_ENV"
+      - name: Open the release PR
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          tag="$(git describe --tags --exact-match)"
-          git push origin main --follow-tags
-          gh workflow run release.yml --ref "$tag"
-          echo "cut ${tag}; release build dispatched" >> "$GITHUB_STEP_SUMMARY"
+          git push origin "release/v${ver}"
+          body="Release v${ver}: version bump + changelog (cut by the cut-release action).
+          Merging this PR tags the merged commit as v${ver} and publishes the release."
+          gh pr create \
+            --base main --head "release/v${ver}" \
+            --title "chore(release): v${ver}" \
+            --body "$body"
+          echo "release PR for v${ver} opened — merge it to tag + publish" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,45 @@
+name: tag-release
+
+# When a release PR lands on main, tag the merged commit and dispatch the
+# release build. Detection works for squash ("chore(release): vX.Y.Z") and
+# merge-commit ("... from .../release/vX.Y.Z") messages, and the version is
+# cross-checked against Cargo.toml so an unrelated commit mentioning a
+# version can't cut a release.
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  actions: write
+
+concurrency: tag-release
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Tag the release merge and dispatch the build
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          ver_msg="$(grep -oE '(chore\(release\): v|release/v)[0-9]+\.[0-9]+\.[0-9]+' <<<"$HEAD_MSG" \
+            | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+          ver_toml="$(grep -m1 '^version = ' Cargo.toml | cut -d'"' -f2)"
+          if [ -z "$ver_msg" ] || [ "$ver_msg" != "$ver_toml" ]; then
+            echo "not a release merge (msg: ${ver_msg:-none}, Cargo.toml: ${ver_toml}) — nothing to do"
+            exit 0
+          fi
+          tag="v${ver_toml}"
+          if git ls-remote --exit-code origin "refs/tags/${tag}" >/dev/null 2>&1; then
+            echo "${tag} already exists — nothing to do"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$tag" -m "$tag"
+          git push origin "$tag"
+          gh workflow run release.yml --ref "$tag"
+          echo "tagged ${tag}; release build dispatched" >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,12 +32,12 @@ condense monorepo as a git submodule, but versions and ships on its own.
   hold that.
 - **Before committing:** `cargo fmt --check`, `cargo clippy --all-targets -D
   warnings`, `cargo test` all green.
-- **Releasing.** The cut-release GitHub Action (or `./scripts/release.sh`
-  locally — same script) computes the next `vX.Y.Z` from the commit log
-  (git-cliff), bumps `Cargo.toml`, regenerates `CHANGELOG.md`, commits, and
-  tags; the tag (pushed, or dispatched by the action) builds the matrix and
-  publishes the GitHub Release. Full procedure in CONTRIBUTING.md — not in
-  the user-facing README.
+- **Releasing.** PR-based (main is branch-protected): the cut-release action
+  (or `./scripts/release.sh --no-tag` on a branch — same script) computes the
+  next `vX.Y.Z` from the commit log (git-cliff), bumps `Cargo.toml`,
+  regenerates `CHANGELOG.md`, and opens a release PR; merging it triggers
+  tag-release, which tags the merged commit and dispatches the build. Full
+  procedure in CONTRIBUTING.md — not in the user-facing README.
 
 ## Layout
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,18 +33,24 @@ clarification only; no narrative or historical paragraphs.
 
 ## Releasing
 
-Releases are cut from `main` with [git-cliff](https://git-cliff.org).
-The usual path is the **cut-release action**: Actions → cut-release →
-Run workflow (leave `version` empty to compute it from the commit log).
-It runs `scripts/release.sh`, pushes the release commit + tag, and
-dispatches the build — needs nothing but repo write access.
+Releases are cut from `main` with [git-cliff](https://git-cliff.org),
+through a PR (main is branch-protected):
 
-The same cut works locally:
+1. Actions → **cut-release** → Run workflow (leave `version` empty to
+   compute it from the commit log). It runs `scripts/release.sh --no-tag`
+   on a `release/vX.Y.Z` branch and opens the release PR.
+2. **Merge the release PR** — that review is the release authorization.
+3. **tag-release** fires on the merge, tags the merged commit `vX.Y.Z`,
+   and dispatches the build; the GitHub Release publishes automatically.
+
+The cut also works locally on a branch:
 
 ```sh
-./scripts/release.sh            # next version from the commit log
-./scripts/release.sh 1.4.0      # or pin it explicitly
+./scripts/release.sh --no-tag           # version from the commit log
+./scripts/release.sh --no-tag 1.4.0     # or pin it explicitly
 ```
+
+then open the PR yourself — tagging still happens on merge.
 
 The script bumps `Cargo.toml` (+ `Cargo.lock`), regenerates `CHANGELOG.md`,
 commits `chore(release): vX.Y.Z`, and creates the `vX.Y.Z` tag. Review, then:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -5,7 +5,15 @@
 #
 #   ./scripts/release.sh            # next version from Conventional Commits
 #   ./scripts/release.sh 1.4.0      # pin it explicitly
+#   ./scripts/release.sh --no-tag   # commit only — CI tags after the release
+#                                   # PR merges (branch-protection flow)
 set -euo pipefail
+
+no_tag=
+if [ "${1:-}" = "--no-tag" ]; then
+  no_tag=1
+  shift
+fi
 
 cd "$(dirname "$0")/.."
 
@@ -35,6 +43,12 @@ git-cliff --tag "$tag" -o CHANGELOG.md
 
 git add Cargo.toml Cargo.lock CHANGELOG.md
 git commit -m "chore(release): ${tag}"
+
+if [ -n "$no_tag" ]; then
+  echo ">> done (no tag). merge the release PR; CI tags the merged commit."
+  exit 0
+fi
+
 git tag -a "$tag" -m "${tag}"
 
 echo ">> done. review, then: git push origin main --follow-tags"


### PR DESCRIPTION
Branch protection blocks direct pushes to main, so cut-release now opens a release/vX.Y.Z PR (release.sh --no-tag) instead of pushing; the new tag-release workflow fires when the merge lands, cross-checks the version against Cargo.toml, tags the merged commit, and dispatches the build. Merging the release PR is the release authorization.