### PR TITLE
chore(release): v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to dense. Format follows Conventional Commits; versions
+are computed by git-cliff.
+
+## [0.1.0] - 2026-06-10
+
+### CI
+- Route the release cut through a PR- Dispatch required checks for bot-created release PRs
+
+### Features
+- Dense — the durable condense CLI
+


### PR DESCRIPTION
Release v0.1.0: version bump + changelog. Merging tags the merged commit as v0.1.0 and publishes the release.