### PR TITLE
ci(release): cut-release prints the PR link instead of creating the PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 name: ci
 
-# workflow_dispatch lets cut-release trigger checks on its release branch —
-# PRs created with GITHUB_TOKEN don't fire pull_request workflows, and the
-# branch-protection required checks must still report on the head SHA.
 on:
   push:
     branches: [main]

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -2,12 +2,10 @@ name: cut-release
 
 # Cut a release from the Actions tab: computes the next vX.Y.Z from
 # Conventional Commits (git-cliff), bumps Cargo.toml, regenerates
-# CHANGELOG.md, and opens a release PR. Merging that PR (the authorized,
-# branch-protection-compliant step) triggers tag-release.yml, which tags
-# the merged commit and dispatches the build.
-#
-# Needs "Allow GitHub Actions to create and approve pull requests" enabled
-# under Settings -> Actions -> General.
+# CHANGELOG.md, pushes a release branch, and prints the PR link. A human
+# opens the PR (bot-created PRs fire no pull_request checks, so the
+# required checks would never report) and merges it — that merge triggers
+# tag-release.yml, which tags the merged commit and dispatches the build.
 on:
   workflow_dispatch:
     inputs:
@@ -18,8 +16,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
-  actions: write
 
 concurrency: cut-release
 
@@ -46,18 +42,14 @@ jobs:
           git checkout -b "release/v${ver}"
           ./scripts/release.sh --no-tag "$ver"
           echo "ver=${ver}" >> "$GITHUB_ENV"
-      - name: Open the release PR
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Push the release branch
         run: |
           git push origin "release/v${ver}"
-          body="Release v${ver}: version bump + changelog (cut by the cut-release action).
-          Merging this PR tags the merged commit as v${ver} and publishes the release."
-          gh pr create \
-            --base main --head "release/v${ver}" \
-            --title "chore(release): v${ver}" \
-            --body "$body"
-          # bot-created PRs don't fire pull_request workflows; run the
-          # required checks on the release branch explicitly
-          gh workflow run ci.yml --ref "release/v${ver}"
-          echo "release PR for v${ver} opened — merge it to tag + publish" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## release v${ver} cut"
+            echo "Open the release PR (your click makes the required checks run):"
+            echo
+            echo "https://github.com/${GITHUB_REPOSITORY}/compare/main...release/v${ver}?expand=1&title=chore(release)%3A%20v${ver}"
+            echo
+            echo "Merging it tags the commit as v${ver} and publishes the release."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,8 @@ condense monorepo as a git submodule, but versions and ships on its own.
 - **Releasing.** PR-based (main is branch-protected): the cut-release action
   (or `./scripts/release.sh --no-tag` on a branch — same script) computes the
   next `vX.Y.Z` from the commit log (git-cliff), bumps `Cargo.toml`,
-  regenerates `CHANGELOG.md`, and opens a release PR; merging it triggers
+  regenerates `CHANGELOG.md`, and pushes a release branch (the run summary
+  links the PR to open); merging that PR triggers
   tag-release, which tags the merged commit and dispatches the build. Full
   procedure in CONTRIBUTING.md — not in the user-facing README.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,8 +38,10 @@ through a PR (main is branch-protected):
 
 1. Actions → **cut-release** → Run workflow (leave `version` empty to
    compute it from the commit log). It runs `scripts/release.sh --no-tag`
-   on a `release/vX.Y.Z` branch and opens the release PR.
-2. **Merge the release PR** — that review is the release authorization.
+   on a `release/vX.Y.Z` branch and prints the PR link in the run summary.
+2. **Open and merge the release PR** — opening it by hand is deliberate
+   (bot-created PRs fire no checks), and the merge is the release
+   authorization.
 3. **tag-release** fires on the merge, tags the merged commit `vX.Y.Z`,
    and dispatches the build; the GitHub Release publishes automatically.
 


### PR DESCRIPTION
Bot-created PRs fire no pull_request workflows, and workflow_dispatch
check runs never enter the PR status rollup — so a bot-opened release PR
sits BLOCKED on required checks forever. The human click that opens the
PR is what makes the checks run; it also drops the need for the
Actions-create-PRs org permission.
