### PR TITLE
ci(release): portable sha256 in the package step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,12 @@ jobs:
           mkdir -p dist
           asset="dense-${{ matrix.platform }}${{ matrix.ext }}"
           cp "$src" "dist/${asset}"
-          sha="$(shasum -a 256 "dist/${asset}" | cut -d' ' -f1)"
+          # sha256sum: linux + windows git-bash; shasum: macos
+          if command -v sha256sum >/dev/null; then
+            sha="$(sha256sum "dist/${asset}" | cut -d' ' -f1)"
+          else
+            sha="$(shasum -a 256 "dist/${asset}" | cut -d' ' -f1)"
+          fi
           printf '{"version":"%s","sha256":"%s"}\n' "$version" "$sha" \
             > "dist/manifest-${{ matrix.platform }}.json"
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Git Bash on the windows runner has sha256sum but not shasum; macos has
shasum but not sha256sum. Try sha256sum first, fall back to shasum.
