### PR TITLE
feat(update): fetch binaries and manifests from GitHub releases

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -11,8 +11,8 @@ $ErrorActionPreference = "Stop"
 
 # Environment endpoints — the serving cli host rewrites these three
 # assignments (and only these) for non-prod zones.
-$CliUrl = "https://cli.condense.chat"
 $ApiUrl = "https://api.condense.chat"
+$ReleaseUrl = "https://github.com/condense-chat/dense"
 $AuthRequired = "1"
 
 function Write-Arrow($msg) {
@@ -30,7 +30,7 @@ New-Item -ItemType Directory -Force -Path $binDir | Out-Null
 # Version we'd install (from the manifest), and what's already installed.
 $targetVersion = ""
 try {
-    $targetVersion = (Invoke-RestMethod -Uri "$CliUrl/windows-x86_64/dense/manifest.json").version
+    $targetVersion = (Invoke-RestMethod -Uri "$ReleaseUrl/releases/latest/download/manifest-windows-x86_64.json").version
 } catch {}
 
 $updating = $false
@@ -38,7 +38,8 @@ $existing = (Get-Command dense -ErrorAction SilentlyContinue).Source
 if ($existing) {
     $installedVersion = ""
     try { $installedVersion = ((& $existing --version) -split ' ')[-1] } catch {}
-    if ($targetVersion -and ($installedVersion -eq $targetVersion)) {
+    # "dev" builds carry no orderable version — always offer the refresh.
+    if ($targetVersion -and ($targetVersion -ne "dev") -and ($installedVersion -eq $targetVersion)) {
         Write-Arrow "dense $targetVersion is already installed. Run ``dense -h`` for more info."
         return
     }
@@ -57,7 +58,7 @@ if ($existing) {
 # An update swaps the binary wherever it already lives; a fresh install
 # lands in our bin dir.
 $dest = if ($existing) { $existing } else { Join-Path $binDir "dense.exe" }
-$url = "$CliUrl/windows-x86_64/dense/stable"
+$url = "$ReleaseUrl/releases/latest/download/dense-windows-x86_64.exe"
 $tmp = "$dest.download"
 Write-Arrow "downloading dense from $url"
 try {
@@ -84,5 +85,6 @@ if ($updating) {
 
 $env:Path = "$binDir;$env:Path"
 if (-not $env:CONDENSE_URL) { $env:CONDENSE_URL = $ApiUrl }
+if (-not $env:CONDENSE_RELEASE_URL) { $env:CONDENSE_RELEASE_URL = $ReleaseUrl }
 $env:CONDENSE_AUTH_REQUIRED = $AuthRequired
 & $dest setup

--- a/install/install.sh
+++ b/install/install.sh
@@ -10,8 +10,8 @@ set -euo pipefail
 
 # Environment endpoints — the serving cli host rewrites these three
 # assignments (and only these) for non-prod zones.
-CLI_URL="https://cli.condense.chat"
 API_URL="https://api.condense.chat"
+RELEASE_URL="https://github.com/condense-chat/dense"
 AUTH_REQUIRED="1"
 
 # Colours, only when stderr is a terminal.
@@ -37,7 +37,7 @@ case "$(uname -m)" in
   aarch64|arm64) arch=aarch64 ;;
   *)
     echo "dense ships ${os} binaries for x86_64 and aarch64; detected $(uname -m)." >&2
-    echo "build from source: ${CLI_URL}" >&2
+    echo "build from source: ${RELEASE_URL}" >&2
     exit 1
     ;;
 esac
@@ -48,7 +48,7 @@ mkdir -p "$bindir"
 
 # Version we'd install (from the manifest), and what's already installed.
 target_version=""
-if manifest="$(curl -fsSL "${CLI_URL}/${platform}/dense/manifest.json" 2>/dev/null)"; then
+if manifest="$(curl -fsSL "${RELEASE_URL}/releases/latest/download/manifest-${platform}.json" 2>/dev/null)"; then
   target_version="$(printf '%s' "$manifest" | sed -n 's/.*"version":"\([^"]*\)".*/\1/p')"
 fi
 
@@ -56,7 +56,9 @@ updating=
 existing="$(command -v dense 2>/dev/null || true)"
 if [ -n "$existing" ]; then
   installed_version="$("$existing" --version 2>/dev/null | awk '{print $NF}')"
-  if [ -n "$target_version" ] && [ "$installed_version" = "$target_version" ]; then
+  # "dev" builds carry no orderable version — always offer the refresh.
+  if [ -n "$target_version" ] && [ "$target_version" != "dev" ] \
+    && [ "$installed_version" = "$target_version" ]; then
     printf '%s %s\n' "$arrow" "${GREEN}dense ${target_version} is already installed.${R} Run ${B}dense -h${R} for more info." >&2
     exit 0
   fi
@@ -74,7 +76,7 @@ if [ -n "$existing" ]; then
   updating=1
 fi
 
-url="${CLI_URL}/${platform}/dense/stable"
+url="${RELEASE_URL}/releases/latest/download/dense-${platform}"
 tmp="$(mktemp)"
 trap 'rm -f "$tmp"' EXIT
 printf '%s %s\n' "$arrow" "downloading dense from ${DIM}${url}${R}" >&2
@@ -92,6 +94,7 @@ fi
 
 export PATH="${bindir}:${PATH}"
 export CONDENSE_URL="${CONDENSE_URL:-$API_URL}"
+export CONDENSE_RELEASE_URL="${CONDENSE_RELEASE_URL:-$RELEASE_URL}"
 export CONDENSE_AUTH_REQUIRED="$AUTH_REQUIRED"
 
 # `curl … | sh` leaves stdin attached to the pipe, not the terminal, so the

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -14,7 +14,7 @@ use serde::Deserialize;
 use crate::api::Api;
 use crate::config::Config;
 use crate::error::{Context, Error};
-use crate::{Result, hosts};
+use crate::{Result, hosts, ui};
 
 const EXPIRES_FALLBACK_SECS: u64 = 600;
 const POLL_FALLBACK_SECS: u64 = 2;
@@ -137,9 +137,27 @@ pub fn resolve_mode(api_host: &str, auth_required: Option<bool>) -> AuthMode {
     }
 }
 
+// The frame wrapper — every exit path closes the cliclack frame.
 async fn device_flow(cfg: &Config) -> Result<()> {
+    let _ = cliclack::intro(ui::cyan("condense login"));
+    let result = device_flow_inner(cfg).await;
+    match &result {
+        Ok(()) => {
+            let _ = cliclack::outro(format!("logged in to {}.", cfg.api_host));
+        }
+        Err(_) => {
+            let _ = cliclack::outro_cancel(ui::yellow("login did not finish."));
+        }
+    }
+    result
+}
+
+async fn device_flow_inner(cfg: &Config) -> Result<()> {
     let api = Api::anonymous(&cfg.api_base_url)?;
-    eprintln!("starting authorization with {} ...", cfg.api_base_url);
+    let _ = cliclack::log::remark(ui::dim(&format!(
+        "starting authorization with {}",
+        cfg.api_base_url
+    )));
     let start: DeviceStart = api
         .post_json("/v1/device/start", &serde_json::json!({}))
         .await?;
@@ -147,9 +165,9 @@ async fn device_flow(cfg: &Config) -> Result<()> {
     let scheme = hosts::default_scheme_for(&cfg.api_host);
     let login_base = hosts::sibling(&cfg.api_host, "login", scheme);
     let link = format!("{login_base}/cli?code={}", start.user_code);
-    eprintln!(
-        "\nOpen this URL in your browser to authorise this terminal:\n\n  {link}\n\nCode: {}\n",
-        start.user_code
+    let _ = cliclack::note(
+        "Open this URL in your browser to authorize this terminal",
+        format!("{link}\n\nCode: {}", start.user_code),
     );
     maybe_open(cfg, &link);
 
@@ -243,15 +261,23 @@ fn read_cred(path: &std::path::Path) -> Option<String> {
 
 async fn register(cfg: &Config) -> Result<()> {
     let api = Api::anonymous(&cfg.api_base_url)?;
-    eprintln!("registering with {} ...", cfg.api_base_url);
+    let spinner = cliclack::spinner();
+    spinner.start(format!("registering with {} ...", cfg.api_base_url));
+    let result = register_request(&api, cfg).await;
+    match &result {
+        Ok(()) => spinner.stop("registered."),
+        Err(e) => spinner.error(format!("{e}")),
+    }
+    result
+}
+
+async fn register_request(api: &Api, cfg: &Config) -> Result<()> {
     let body = api.post_text("/v1/register").await?;
     let uuid = body.trim();
     if uuid.is_empty() {
         return Err(Error::Auth("register returned an empty user id".into()));
     }
-    write_secret(&cfg.user_file(), uuid)?;
-    eprintln!("registered.");
-    Ok(())
+    write_secret(&cfg.user_file(), uuid)
 }
 
 fn write_secret(path: &std::path::Path, value: &str) -> Result<()> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,7 @@ use crate::error::{Context, Error};
 use crate::profile::Profile;
 
 pub const DEFAULT_API_URL: &str = "https://api.condense.chat";
+pub const DEFAULT_RELEASE_URL: &str = "https://github.com/condense-chat/dense";
 
 pub struct Config {
     /// Condense api base, e.g. `https://api.condense.chat`.
@@ -34,6 +35,9 @@ pub struct Config {
     profile_name: String,
     /// `$DENSE_PROFILE_URL` — overrides where `dense profile` fetches from.
     profile_url: Option<String>,
+    /// Release-asset base — `$CONDENSE_RELEASE_URL` if set, else the
+    /// profile's declared value (`None` = the baked GitHub default).
+    release_url: Option<String>,
     /// `$CONDENSE_UPSTREAM_URL` — routes the proxy to a non-default upstream.
     upstream: Option<String>,
 }
@@ -45,6 +49,7 @@ impl Config {
             name: self.profile_name.clone(),
             api_url: self.api_base_url.clone(),
             auth_required: self.auth_required,
+            release_url: self.release_url.clone(),
         }
     }
 
@@ -128,6 +133,12 @@ impl Config {
         self.profile_url.as_deref()
     }
 
+    /// Base URL release assets (binaries + manifests) are fetched from —
+    /// GitHub releases unless the profile serves its own builds (dev).
+    pub fn release_base(&self) -> &str {
+        self.release_url.as_deref().unwrap_or(DEFAULT_RELEASE_URL)
+    }
+
     /// Persist the active profile so future bare runs target the same api:
     /// `prod` clears the target, anything else caches + records it.
     pub fn remember_profile(&self) -> Result<()> {
@@ -161,6 +172,7 @@ impl Config {
             open_links: !env_flag("CONDENSE_NO_OPEN"),
             profile_name: profile.name,
             profile_url: env_value("DENSE_PROFILE_URL"),
+            release_url: env_value("CONDENSE_RELEASE_URL").or(profile.release_url),
             upstream: env_value("CONDENSE_UPSTREAM_URL"),
         })
     }
@@ -312,6 +324,7 @@ fn profile_for_url(config_dir: &Path, url: &str) -> Profile {
         name: host_label(&url),
         api_url: url,
         auth_required: None,
+        release_url: None,
     }
 }
 
@@ -400,6 +413,39 @@ mod tests {
         assert_eq!(p.name, "api.condense.evil.com");
         let p = profile_for_url(dir.path(), "http://api.dev.condense.localhost:8080");
         assert_eq!(p.name, "api.dev.condense.localhost-8080");
+    }
+
+    // Old profile.toml files predate release_url; they must keep parsing,
+    // and a declared release_url must survive the cache round-trip.
+    #[test]
+    fn release_url_is_optional_and_round_trips() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(dir.path().join("stage")).expect("mkdir");
+        std::fs::write(
+            dir.path().join("stage/profile.toml"),
+            "name = \"stage\"\napi_url = \"https://api.stage.condense.chat\"\n",
+        )
+        .expect("write profile");
+        let p = read_cached_profile(dir.path(), "stage").expect("parse");
+        assert_eq!(p.release_url, None);
+
+        std::fs::create_dir_all(dir.path().join("dev")).expect("mkdir");
+        std::fs::write(
+            dir.path().join("dev/profile.toml"),
+            toml::to_string_pretty(&Profile {
+                name: "dev".into(),
+                api_url: "http://api.dev.condense.localhost".into(),
+                auth_required: None,
+                release_url: Some("http://cli.dev.condense.localhost".into()),
+            })
+            .expect("serialize"),
+        )
+        .expect("write profile");
+        let p = read_cached_profile(dir.path(), "dev").expect("parse");
+        assert_eq!(
+            p.release_url.as_deref(),
+            Some("http://cli.dev.condense.localhost")
+        );
     }
 
     #[test]

--- a/src/env_file.rs
+++ b/src/env_file.rs
@@ -28,6 +28,20 @@ pub enum PathWiring {
     Wired,
 }
 
+/// How to make the dirs visible when no shell profile sources the env file
+/// (wiring skipped or failed) — restarting a shell would not help there.
+pub fn activate_hint(cfg: &Config) -> String {
+    #[cfg(windows)]
+    {
+        let _ = cfg;
+        "add the dense directories to your PATH, then open a new terminal".to_string()
+    }
+    #[cfg(not(windows))]
+    {
+        format!("run `. \"{}\"`", cfg.sh_path(&cfg.env_file()))
+    }
+}
+
 #[cfg(not(windows))]
 pub fn ensure_env(cfg: &Config, modify_path: bool) -> Result<PathWiring> {
     std::fs::create_dir_all(cfg.shim_dir()).ctx("creating dense shim dir")?;

--- a/src/env_file.rs
+++ b/src/env_file.rs
@@ -16,10 +16,12 @@ const END: &str = "# <<< dense <<<";
 #[cfg(not(windows))]
 const PROFILES: &[&str] = &[".profile", ".bashrc", ".zshrc", ".bash_profile"];
 
-/// Outcome of wiring the dirs into PATH.
+/// Outcome of wiring the dirs into PATH. No printing happens here — the
+/// caller renders the notes in whatever UI it is running (cliclack frame
+/// in setup, plain lines for `dense persist`).
 pub enum PathWiring {
-    /// Something was unwritable; the user must add the dirs themselves.
-    Manual,
+    /// Something was unwritable; the notes say what to finish by hand.
+    Manual(Vec<String>),
     /// `--no-modify-path`: PATH was left untouched by request.
     Skipped,
     /// Wired with no failures.
@@ -33,10 +35,11 @@ pub fn ensure_env(cfg: &Config, modify_path: bool) -> Result<PathWiring> {
     if !modify_path {
         return Ok(PathWiring::Skipped);
     }
-    if ensure_sourced(cfg)? {
+    let notes = ensure_sourced(cfg)?;
+    if notes.is_empty() {
         Ok(PathWiring::Wired)
     } else {
-        Ok(PathWiring::Manual)
+        Ok(PathWiring::Manual(notes))
     }
 }
 
@@ -50,14 +53,14 @@ pub fn ensure_env(cfg: &Config, modify_path: bool) -> Result<PathWiring> {
     let dirs = [cfg.bin_dir(), cfg.shim_dir()];
     match set_user_path(&dirs, true) {
         Ok(()) => Ok(PathWiring::Wired),
-        Err(e) => {
-            eprintln!("note: could not update your PATH ({e}).");
-            eprintln!("add these directories to your PATH yourself:");
-            for dir in &dirs {
-                eprintln!("  {}", dir.display());
-            }
-            Ok(PathWiring::Manual)
-        }
+        Err(e) => Ok(PathWiring::Manual(vec![
+            format!("could not update your PATH ({e})"),
+            format!(
+                "add these directories to your PATH yourself:\n  {}\n  {}",
+                dirs[0].display(),
+                dirs[1].display()
+            ),
+        ])),
     }
 }
 
@@ -138,10 +141,10 @@ fn add_block(path: &std::path::Path, block: &str) -> std::io::Result<()> {
     std::fs::write(path, next)
 }
 
-/// Returns `true` if the env file is now sourced from every targeted profile,
-/// `false` if any was unwritable (a note + the manual line are printed then).
+/// Returns the manual-action notes for anything that couldn't be wired —
+/// empty means the env file is sourced from every targeted profile.
 #[cfg(not(windows))]
-fn ensure_sourced(cfg: &Config) -> Result<bool> {
+fn ensure_sourced(cfg: &Config) -> Result<Vec<String>> {
     let line = format!(". \"{}\"", cfg.sh_path(&cfg.env_file()));
     let block = format!("{BEGIN}\n{line}\n{END}\n");
 
@@ -156,25 +159,23 @@ fn ensure_sourced(cfg: &Config) -> Result<bool> {
 
     // A read-only profile is the user's to fix — note it and move on rather
     // than aborting persist; the shims are already installed.
-    let mut unwritable = Vec::new();
+    let mut notes = Vec::new();
+    let mut unwritable = false;
     for path in targets {
         if let Err(e) = add_block(&path, &block) {
-            unwritable.push((path, e));
+            unwritable = true;
+            notes.push(format!("{} is not writable ({e})", path.display()));
         }
     }
     if let Err(e) = write_fish_conf(cfg) {
-        eprintln!("note: could not write the fish PATH config ({e}).");
+        notes.push(format!("could not write the fish PATH config ({e})"));
     }
-
-    if unwritable.is_empty() {
-        return Ok(true);
+    if unwritable {
+        notes.push(format!(
+            "add this line to your shell profile yourself:\n  {line}"
+        ));
     }
-    eprintln!();
-    for (path, e) in &unwritable {
-        eprintln!("note: {} is not writable ({e}).", path.display());
-    }
-    eprintln!("add this line to your shell profile yourself:\n  {line}");
-    Ok(false)
+    Ok(notes)
 }
 
 /// `conf.d/dense.fish` under an existing fish config — `None` when the user

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -31,19 +31,33 @@ pub struct Record {
     pub tools: BTreeMap<String, String>,
 }
 
+/// What [`install_shims`] did — the caller renders it in whatever UI it is
+/// running (cliclack frame in setup, plain lines for `dense persist`).
+#[derive(Default)]
+pub struct ShimReport {
+    /// `(tool, shim path)` for every shim written.
+    pub persisted: Vec<(String, PathBuf)>,
+    /// Tools selected but not yet supported.
+    pub skipped: Vec<String>,
+    /// Shims written for tools that aren't installed yet.
+    pub warnings: Vec<String>,
+}
+
 struct ToolSpec {
     available: bool,
     install_hint: &'static str,
     name: &'static str,
 }
 
-/// Install shims for the targets and record them. Does not touch PATH.
-pub fn install_shims(cfg: &Config, targets: &[String]) -> Result<()> {
+/// Install shims for the targets and record them. Does not touch PATH and
+/// prints nothing — outcomes come back in the [`ShimReport`].
+pub fn install_shims(cfg: &Config, targets: &[String]) -> Result<ShimReport> {
     let selected = select(targets)?;
     let mut rec = load_record(cfg);
+    let mut report = ShimReport::default();
     for spec in selected {
         if !spec.available {
-            println!("{}: coming soon — skipped.", spec.name);
+            report.skipped.push(spec.name.to_string());
             continue;
         }
         match tool::resolve_real(cfg, spec.name) {
@@ -53,20 +67,19 @@ pub fn install_shims(cfg: &Config, targets: &[String]) -> Result<()> {
             }
             Err(_) => {
                 rec.tools.insert(spec.name.to_string(), String::new());
-                eprintln!(
-                    "warning: `{}` is not on PATH yet — shim installed; install it: {}",
+                report.warnings.push(format!(
+                    "`{}` is not on PATH yet — shim installed; install it: {}",
                     spec.name, spec.install_hint
-                );
+                ));
             }
         }
         write_shim(cfg, spec.name)?;
-        println!(
-            "persisted {} -> {}",
-            spec.name,
-            shim_path(cfg, spec.name).display()
-        );
+        report
+            .persisted
+            .push((spec.name.to_string(), shim_path(cfg, spec.name)));
     }
-    save_record(cfg, &rec)
+    save_record(cfg, &rec)?;
+    Ok(report)
 }
 
 pub fn load_record(cfg: &Config) -> Record {
@@ -78,7 +91,16 @@ pub fn load_record(cfg: &Config) -> Record {
 
 pub fn persist(cfg: &Config, targets: &[String], modify_path: bool) -> Result<()> {
     let wiring = env_file::ensure_env(cfg, modify_path)?;
-    install_shims(cfg, targets)?;
+    let report = install_shims(cfg, targets)?;
+    for (name, shim) in &report.persisted {
+        println!("persisted {name} -> {}", shim.display());
+    }
+    for name in &report.skipped {
+        println!("{name}: coming soon — skipped.");
+    }
+    for warning in &report.warnings {
+        eprintln!("warning: {warning}");
+    }
     report_wiring(cfg, &wiring);
     Ok(())
 }
@@ -92,9 +114,12 @@ pub fn report_wiring(cfg: &Config, wiring: &env_file::PathWiring) {
         env_file::PathWiring::Skipped => {
             println!("PATH left unchanged (--no-modify-path).");
         }
-        env_file::PathWiring::Manual => {
+        env_file::PathWiring::Manual(notes) => {
+            for note in notes {
+                println!("note: {note}");
+            }
             println!(
-                "PATH not wired — add the dirs noted above, then {}.",
+                "PATH not wired — after the steps above, {}.",
                 env_file::reload_hint(cfg)
             );
         }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -16,6 +16,10 @@ pub struct Profile {
     #[serde(default)]
     pub auth_required: Option<bool>,
     pub name: String,
+    /// Where release assets come from; `None` means the baked GitHub
+    /// releases default. Dev sets it to serve its own local builds.
+    #[serde(default)]
+    pub release_url: Option<String>,
 }
 
 impl Profile {
@@ -25,6 +29,7 @@ impl Profile {
             name: "prod".to_string(),
             api_url: DEFAULT_API_URL.to_string(),
             auth_required: Some(true),
+            release_url: None,
         }
     }
 }
@@ -89,6 +94,7 @@ async fn from_source(name: &str, source: &str) -> Result<Profile> {
             name: name.to_string(),
             api_url: source.trim_end_matches('/').to_string(),
             auth_required: None,
+            release_url: None,
         });
     }
     let zone = source.trim_matches('/');
@@ -102,6 +108,7 @@ async fn from_source(name: &str, source: &str) -> Result<Profile> {
             name: name.to_string(),
             api_url: format!("{scheme}://api.{zone}"),
             auth_required: None,
+            release_url: None,
         }),
     }
 }

--- a/src/selfupdate.rs
+++ b/src/selfupdate.rs
@@ -1,9 +1,10 @@
 //! `dense self update` / `dense self uninstall`.
 //!
-//! Update fetches the per-platform manifest from the cli host, compares
-//! versions, downloads the new binary, verifies its sha256, and atomically
-//! replaces the running executable. Uninstall removes shims, the env wiring,
-//! dense's data dir, and the binary — leaving credentials in place.
+//! Update fetches the per-platform manifest from the release host (GitHub
+//! releases unless the profile serves its own builds), compares versions,
+//! downloads the new binary, verifies its sha256, and atomically replaces
+//! the running executable. Uninstall removes shims, the env wiring, dense's
+//! data dir, and the binary — leaving credentials in place.
 
 use backon::{ExponentialBuilder, Retryable};
 use serde::Deserialize;
@@ -12,7 +13,7 @@ use sha2::{Digest, Sha256};
 use crate::api::Api;
 use crate::config::Config;
 use crate::error::{Context, Error};
-use crate::{Result, env_file, hosts, persist};
+use crate::{Result, env_file, persist};
 
 #[derive(Deserialize)]
 struct Manifest {
@@ -40,30 +41,41 @@ pub fn uninstall(cfg: &Config) -> Result<()> {
 
 pub async fn update(cfg: &Config) -> Result<()> {
     let platform = platform();
-    let api = Api::anonymous(&cli_base(cfg))?;
+    let api = Api::anonymous(cfg.release_base())?;
 
-    let manifest_path = format!("/{platform}/dense/manifest.json");
+    let manifest_path = format!("/releases/latest/download/manifest-{platform}.json");
     let manifest: Manifest = (|| api.get_json::<Manifest>(&manifest_path))
         .retry(ExponentialBuilder::default().with_max_times(2))
         .await?;
 
     let current = semver::Version::parse(env!("CARGO_PKG_VERSION")).ctx("own version")?;
-    let latest = semver::Version::parse(&manifest.version).ctx("manifest version")?;
-    if latest <= current {
-        println!("dense {current} is already up to date.");
-        return Ok(());
+    match semver::Version::parse(&manifest.version) {
+        Ok(latest) if latest <= current => {
+            println!("dense {current} is already up to date.");
+            return Ok(());
+        }
+        Ok(latest) => println!("updating dense {current} -> {latest} ..."),
+        // A non-semver version (a dev broker's "dev") can't be ordered;
+        // the manifest hash against the running binary decides instead.
+        Err(_) => {
+            if own_sha256()?.eq_ignore_ascii_case(&manifest.sha256) {
+                println!(
+                    "dense {current} is already up to date ({} build).",
+                    manifest.version
+                );
+                return Ok(());
+            }
+            println!("updating dense {current} -> {} ...", manifest.version);
+        }
     }
-    println!("updating dense {current} -> {latest} ...");
 
     let url = manifest
         .url
         .clone()
-        .unwrap_or_else(|| format!("/{platform}/dense/{}", manifest.version));
+        .unwrap_or_else(|| format!("/releases/latest/download/{}", asset_name(&platform)));
     let bytes = api.get_bytes(&url).await?;
 
-    let mut hasher = Sha256::new();
-    hasher.update(&bytes);
-    let got = hex::encode(hasher.finalize());
+    let got = sha256_hex(&bytes);
     if !got.eq_ignore_ascii_case(&manifest.sha256) {
         return Err(Error::msg(format!(
             "sha256 mismatch: manifest {}, downloaded {got}",
@@ -72,13 +84,21 @@ pub async fn update(cfg: &Config) -> Result<()> {
     }
 
     replace_self(&bytes)?;
-    println!("updated to {latest}.");
+    println!("updated to {}.", manifest.version);
     Ok(())
 }
 
-fn cli_base(cfg: &Config) -> String {
-    let scheme = hosts::default_scheme_for(&cfg.api_host);
-    hosts::sibling(&cfg.api_host, "cli", scheme)
+/// Release asset name for a platform key (e.g. `dense-linux-x86_64`).
+fn asset_name(platform: &str) -> String {
+    let suffix = if cfg!(windows) { ".exe" } else { "" };
+    format!("dense-{platform}{suffix}")
+}
+
+/// Digest of the running binary — what a non-semver manifest compares to.
+fn own_sha256() -> Result<String> {
+    let exe = std::env::current_exe().ctx("locating the running binary")?;
+    let bytes = std::fs::read(&exe).ctx("reading the running binary")?;
+    Ok(sha256_hex(&bytes))
 }
 
 /// `<os>-<arch>` — the platform key release assets and manifests are
@@ -116,4 +136,10 @@ fn replace_self(bytes: &[u8]) -> Result<()> {
     let res = self_replace::self_replace(&tmp).ctx("installing the new binary");
     let _ = std::fs::remove_file(&tmp);
     res
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -12,6 +12,80 @@ use crate::{Result, env_file, persist, ui};
 
 pub async fn run(cfg: &Config) -> Result<()> {
     let interactive = std::io::stdin().is_terminal();
+    let res = wizard(cfg, interactive);
+    if res.is_err() && interactive {
+        let _ = cliclack::outro_cancel(ui::yellow("setup did not finish."));
+    }
+    res
+}
+
+/// Ask a yes/no question with a dim one-line explainer. Interactive: a
+/// cliclack confirm on the tty (`None` = cancelled); otherwise echo the
+/// default taken.
+fn ask(interactive: bool, question: &str, explain: &str, default_yes: bool) -> Option<bool> {
+    if !interactive {
+        let default = if default_yes { "yes" } else { "no" };
+        println!("{question}");
+        println!("{}", ui::dim(explain));
+        println!("{}", ui::dim(&format!("[no tty — default: {default}]")));
+        println!();
+        return Some(default_yes);
+    }
+    let _ = cliclack::log::remark(ui::dim(explain));
+    cliclack::confirm(question)
+        .initial_value(default_yes)
+        .interact()
+        .ok()
+}
+
+// A cancelled prompt already closed the frame ("Operation cancelled.").
+fn cancelled(interactive: bool) -> Result<()> {
+    if interactive {
+        println!("{}", ui::dim("rerun `dense setup` anytime."));
+    }
+    Ok(())
+}
+
+fn on_path(dir: &Path) -> bool {
+    std::env::var_os("PATH")
+        .map(|p| std::env::split_paths(&p).any(|d| d == dir))
+        .unwrap_or(false)
+}
+
+/// Warnings for wired dirs that aren't visible to this shell yet.
+fn path_warnings(cfg: &Config, persisted: bool) -> Vec<String> {
+    let reload = env_file::reload_hint(cfg);
+    let mut out = Vec::new();
+    if !on_path(&cfg.bin_dir()) {
+        out.push(format!(
+            "{} isn't on your PATH yet; {reload}.",
+            cfg.bin_dir().display()
+        ));
+    } else if persisted && !on_path(&cfg.shim_dir()) {
+        out.push(format!("{reload} so `claude` routes through dense."));
+    }
+    out
+}
+
+fn start_hint(persisted: bool) -> String {
+    let start = if persisted { "claude" } else { "dense claude" };
+    format!(
+        "Run `{}` to start saving, or `{}` for help.",
+        ui::cyan(start),
+        ui::cyan("dense -h")
+    )
+}
+
+/// A warning that stays inside the cliclack frame when there is one.
+fn warn(interactive: bool, text: &str) {
+    if interactive {
+        let _ = cliclack::log::warning(text);
+    } else {
+        eprintln!("{}", ui::yellow(text));
+    }
+}
+
+fn wizard(cfg: &Config, interactive: bool) -> Result<()> {
     cfg.remember_profile()?;
 
     let note = format!(
@@ -25,23 +99,36 @@ pub async fn run(cfg: &Config) -> Result<()> {
         println!("{}\n", ui::dim(&note));
     }
 
-    let do_persist = ask(
+    let Some(do_persist) = ask(
         interactive,
         "Use condense for all claude sessions?",
         "the bare `claude` command will point at the dense claude wrapper.",
         true,
-    );
+    ) else {
+        return cancelled(interactive);
+    };
 
-    let modify_path = ask(
+    let Some(modify_path) = ask(
         interactive,
         "Add dense to your PATH?",
         &format!("{}.", env_file::path_change_summary(cfg)),
         true,
-    );
+    ) else {
+        return cancelled(interactive);
+    };
 
-    env_file::ensure_env(cfg, modify_path)?;
+    match env_file::ensure_env(cfg, modify_path)? {
+        env_file::PathWiring::Manual(notes) => warn(interactive, &notes.join("\n")),
+        env_file::PathWiring::Skipped | env_file::PathWiring::Wired => {}
+    }
     if do_persist {
-        persist::install_shims(cfg, &["claude".to_string()])?;
+        let report = persist::install_shims(cfg, &["claude".to_string()])?;
+        for warning in &report.warnings {
+            warn(interactive, warning);
+        }
+    }
+    for warning in path_warnings(cfg, do_persist) {
+        warn(interactive, &warning);
     }
 
     if interactive {
@@ -49,58 +136,5 @@ pub async fn run(cfg: &Config) -> Result<()> {
     } else {
         println!("\n{}", start_hint(do_persist));
     }
-    path_warnings(cfg, do_persist);
     Ok(())
-}
-
-/// Ask a yes/no question with a dim one-line explainer. Interactive: a
-/// cliclack confirm on the tty; otherwise echo the default taken.
-fn ask(interactive: bool, question: &str, explain: &str, default_yes: bool) -> bool {
-    if !interactive {
-        let default = if default_yes { "yes" } else { "no" };
-        println!("{question}");
-        println!("{}", ui::dim(explain));
-        println!("{}", ui::dim(&format!("[no tty — default: {default}]")));
-        println!();
-        return default_yes;
-    }
-    let _ = cliclack::log::remark(ui::dim(explain));
-    cliclack::confirm(question)
-        .initial_value(default_yes)
-        .interact()
-        .unwrap_or(default_yes)
-}
-
-fn on_path(dir: &Path) -> bool {
-    std::env::var_os("PATH")
-        .map(|p| std::env::split_paths(&p).any(|d| d == dir))
-        .unwrap_or(false)
-}
-
-/// Warn when the wired dirs aren't visible to this shell yet.
-fn path_warnings(cfg: &Config, persisted: bool) {
-    let reload = env_file::reload_hint(cfg);
-    if !on_path(&cfg.bin_dir()) {
-        println!(
-            "{}",
-            ui::yellow(&format!(
-                "{} isn't on your PATH yet; {reload}.",
-                cfg.bin_dir().display()
-            ))
-        );
-    } else if persisted && !on_path(&cfg.shim_dir()) {
-        println!(
-            "{}",
-            ui::yellow(&format!("{reload} so `claude` routes through dense."))
-        );
-    }
-}
-
-fn start_hint(persisted: bool) -> String {
-    let start = if persisted { "claude" } else { "dense claude" };
-    format!(
-        "Run `{}` to start saving, or `{}` for help.",
-        ui::cyan(start),
-        ui::cyan("dense -h")
-    )
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -52,17 +52,24 @@ fn on_path(dir: &Path) -> bool {
         .unwrap_or(false)
 }
 
-/// Warnings for wired dirs that aren't visible to this shell yet.
-fn path_warnings(cfg: &Config, persisted: bool) -> Vec<String> {
-    let reload = env_file::reload_hint(cfg);
+/// Warnings for dirs that aren't visible to this shell yet. A restart only
+/// helps once the profile wiring exists; otherwise point at the immediate
+/// activation instead.
+fn path_warnings(cfg: &Config, persisted: bool, wiring: &env_file::PathWiring) -> Vec<String> {
+    let hint = match wiring {
+        env_file::PathWiring::Wired => env_file::reload_hint(cfg),
+        env_file::PathWiring::Manual(_) | env_file::PathWiring::Skipped => {
+            env_file::activate_hint(cfg)
+        }
+    };
     let mut out = Vec::new();
     if !on_path(&cfg.bin_dir()) {
         out.push(format!(
-            "{} isn't on your PATH yet; {reload}.",
+            "{} isn't on your PATH yet; {hint}.",
             cfg.bin_dir().display()
         ));
     } else if persisted && !on_path(&cfg.shim_dir()) {
-        out.push(format!("{reload} so `claude` routes through dense."));
+        out.push(format!("{hint} so `claude` routes through dense."));
     }
     out
 }
@@ -117,9 +124,9 @@ fn wizard(cfg: &Config, interactive: bool) -> Result<()> {
         return cancelled(interactive);
     };
 
-    match env_file::ensure_env(cfg, modify_path)? {
-        env_file::PathWiring::Manual(notes) => warn(interactive, &notes.join("\n")),
-        env_file::PathWiring::Skipped | env_file::PathWiring::Wired => {}
+    let wiring = env_file::ensure_env(cfg, modify_path)?;
+    if let env_file::PathWiring::Manual(notes) = &wiring {
+        warn(interactive, &notes.join("\n"));
     }
     if do_persist {
         let report = persist::install_shims(cfg, &["claude".to_string()])?;
@@ -127,7 +134,7 @@ fn wizard(cfg: &Config, interactive: bool) -> Result<()> {
             warn(interactive, warning);
         }
     }
-    for warning in path_warnings(cfg, do_persist) {
+    for warning in path_warnings(cfg, do_persist, &wiring) {
         warn(interactive, &warning);
     }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -14,8 +14,15 @@ pub async fn run(cfg: &Config) -> Result<()> {
     let interactive = std::io::stdin().is_terminal();
     cfg.remember_profile()?;
 
+    let note = format!(
+        "dense is open source — read the code: {}",
+        env!("CARGO_PKG_REPOSITORY")
+    );
     if interactive {
         let _ = cliclack::intro(ui::cyan("condense setup"));
+        let _ = cliclack::log::remark(ui::dim(&note));
+    } else {
+        println!("{}\n", ui::dim(&note));
     }
 
     let do_persist = ask(


### PR DESCRIPTION
GitHub Releases becomes the canonical fetch area (v0.2.0):

- Install scripts download `releases/latest/download/dense-<platform>` and read `manifest-<platform>.json` from `RELEASE_URL`, a new constant in the rewritable block. `CLI_URL` leaves the scripts — nothing used it anymore.
- The scripts export `CONDENSE_RELEASE_URL`, which `Config` resolves (env over profile) and `setup` persists, so a dev install keeps fetching from its own broker.
- Profiles gain an optional `release_url` (absent = baked GitHub default; old profile.toml files keep parsing).
- `dense self update` fetches from the release base; a non-semver manifest version (dev's `dev`) is decided by sha256-comparing the manifest hash against the running binary.

No legacy broker support — v0.1.x was the bootstrap. The monorepo router grows the GitHub-shaped dev routes in a separate PR.

Gate: fmt, clippy + tests on linux and x86_64-pc-windows-gnu (wine).