### PR TITLE
feat(config): XDG-style config and data dirs on macOS

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -4,9 +4,9 @@
 //! config dir; every other profile nests under `<config>/<profile>/`. The
 //! active profile is `prod` unless a `<config>/target` pointer (written by
 //! `dense profile <name>`) says otherwise. Config files are TOML. The config
-//! and data directories are the platform-native ones (via the `directories`
-//! crate): on Linux `~/.config/dense` + `~/.local/share/dense`, on Windows
-//! `%APPDATA%\dense` + `%LOCALAPPDATA%\dense`.
+//! and data directories are XDG-style on every unix (macOS included):
+//! `~/.config/dense` + `~/.local/share/dense`, honoring `$XDG_CONFIG_HOME` /
+//! `$XDG_DATA_HOME`; on Windows `%APPDATA%\dense` + `%LOCALAPPDATA%\dense`.
 
 use std::path::{Path, PathBuf};
 
@@ -156,9 +156,17 @@ impl Config {
     /// binary won't guess a non-prod host.
     pub fn resolve(url_override: Option<String>, env_override: Option<String>) -> Result<Self> {
         let dirs = BaseDirs::new().ok_or_else(|| Error::msg("cannot determine home directory"))?;
-        let config_dir = dirs.config_dir().join("dense");
-        let data_dir = dirs.data_local_dir().join("dense");
         let home = dirs.home_dir().to_path_buf();
+        #[cfg(windows)]
+        let (config_dir, data_dir) = (
+            dirs.config_dir().join("dense"),
+            dirs.data_local_dir().join("dense"),
+        );
+        #[cfg(not(windows))]
+        let (config_dir, data_dir) = (
+            xdg_dir("XDG_CONFIG_HOME", &home, ".config").join("dense"),
+            xdg_dir("XDG_DATA_HOME", &home, ".local/share").join("dense"),
+        );
         let profile = resolve_profile(&config_dir, url_override, env_override)?;
         let api_base_url = profile.api_url.trim_end_matches('/').to_string();
         let api_host = crate::hosts::host_of(&api_base_url);
@@ -366,6 +374,17 @@ fn resolve_profile(
         eprintln!("warning: target profile `{target}` is not registered; using prod.");
     }
     Ok(Profile::prod())
+}
+
+/// `$<var>` if set to an absolute path, else `<home>/<default>` — the XDG
+/// base-dir rule, applied on every unix so macOS doesn't drift into
+/// `~/Library/Application Support`.
+#[cfg(not(windows))]
+fn xdg_dir(var: &str, home: &Path, default: &str) -> PathBuf {
+    std::env::var_os(var)
+        .map(PathBuf::from)
+        .filter(|p| p.is_absolute())
+        .unwrap_or_else(|| home.join(default))
 }
 
 #[cfg(test)]

--- a/src/env_file.rs
+++ b/src/env_file.rs
@@ -78,6 +78,16 @@ pub fn ensure_env(cfg: &Config, modify_path: bool) -> Result<PathWiring> {
     }
 }
 
+/// Whether any shell profile currently sources the dense env file (the
+/// signal that the user accepted PATH wiring, vs `--no-modify-path`).
+#[cfg(target_os = "macos")]
+pub fn is_wired(cfg: &Config) -> bool {
+    PROFILES
+        .iter()
+        .any(|n| std::fs::read_to_string(cfg.home().join(n)).is_ok_and(|s| s.contains(BEGIN)))
+        || fish_conf_path(cfg).is_some_and(|p| p.is_file())
+}
+
 /// One-line description of the PATH change `ensure_env` would make, for the
 /// setup prompt.
 pub fn path_change_summary(cfg: &Config) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod env_file;
 mod error;
 mod harness;
 mod hosts;
+mod migrate;
 mod persist;
 mod profile;
 mod selfupdate;
@@ -47,6 +48,9 @@ async fn main() -> EyreResult<()> {
     init_tracing(cli.verbose);
 
     let cfg = Config::resolve(cli.url.clone(), cli.environment.clone())?;
+    if let Err(e) = migrate::run(&cfg) {
+        eprintln!("warning: could not finish moving dense files to their new dirs: {e}");
+    }
 
     let result: Result<()> = match cli.command {
         Command::Status => {

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -1,0 +1,133 @@
+//! One-shot move of a pre-XDG macOS install out of
+//! `~/Library/Application Support/dense` into the unix dirs, re-wiring the
+//! PATH env file the shell profiles source.
+
+use crate::Result;
+use crate::config::Config;
+
+#[cfg(target_os = "macos")]
+pub fn run(cfg: &Config) -> Result<()> {
+    use crate::env_file;
+
+    let old = cfg
+        .home()
+        .join("Library")
+        .join("Application Support")
+        .join("dense");
+    if !old.is_dir() {
+        return Ok(());
+    }
+    // Re-add profile blocks only where they already were — `--no-modify-path`
+    // users keep their profiles untouched; the env file is refreshed either way.
+    let rewire = env_file::is_wired(cfg);
+    move_entries(&old, cfg.config_dir(), &cfg.data_dir())?;
+    if rewire {
+        env_file::unwire(cfg)?;
+    }
+    if let env_file::PathWiring::Manual(notes) = env_file::ensure_env(cfg, rewire)? {
+        for note in notes {
+            eprintln!("note: {note}");
+        }
+    }
+    println!(
+        "moved dense files from {} to {} and {}",
+        old.display(),
+        cfg.config_dir().display(),
+        cfg.data_dir().display()
+    );
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn run(_cfg: &Config) -> Result<()> {
+    Ok(())
+}
+
+/// Sort the old flat dir (config and data shared it) into the two new homes,
+/// skipping anything the new dirs already hold. The old dir is removed only
+/// once it is empty.
+#[cfg(any(target_os = "macos", test))]
+fn move_entries(
+    old: &std::path::Path,
+    config_dir: &std::path::Path,
+    data_dir: &std::path::Path,
+) -> Result<()> {
+    use crate::error::Context;
+
+    const DATA_ENTRIES: &[&str] = &["bin", "env", "persist.toml"];
+    std::fs::create_dir_all(config_dir).ctx("creating dense config dir")?;
+    std::fs::create_dir_all(data_dir).ctx("creating dense data dir")?;
+    for entry in std::fs::read_dir(old).ctx("reading the old dense dir")? {
+        let entry = entry.ctx("reading the old dense dir")?;
+        let name = entry.file_name();
+        let is_data = name.to_str().is_some_and(|n| DATA_ENTRIES.contains(&n));
+        let dest = if is_data { data_dir } else { config_dir }.join(&name);
+        if dest.exists() {
+            continue;
+        }
+        std::fs::rename(entry.path(), &dest).ctx(format!(
+            "moving {} to {}",
+            entry.path().display(),
+            dest.display()
+        ))?;
+    }
+    let _ = std::fs::remove_dir(old);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sorts_entries_and_removes_emptied_old_dir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let old = tmp.path().join("Application Support/dense");
+        std::fs::create_dir_all(old.join("bin")).expect("mkdir");
+        std::fs::create_dir_all(old.join("stage")).expect("mkdir");
+        for (path, body) in [
+            ("token", "tok"),
+            ("target", "stage\n"),
+            ("stage/profile.toml", "name = \"stage\"\n"),
+            ("persist.toml", "[tools]\n"),
+            ("env", "#!/bin/sh\n"),
+            ("bin/claude", "#!/bin/sh\n"),
+        ] {
+            std::fs::write(old.join(path), body).expect("seed");
+        }
+
+        let config_dir = tmp.path().join(".config/dense");
+        let data_dir = tmp.path().join(".local/share/dense");
+        move_entries(&old, &config_dir, &data_dir).expect("migrate");
+
+        for p in ["token", "target", "stage/profile.toml"] {
+            assert!(config_dir.join(p).is_file(), "missing config entry {p}");
+        }
+        for p in ["persist.toml", "env", "bin/claude"] {
+            assert!(data_dir.join(p).is_file(), "missing data entry {p}");
+        }
+        assert!(!old.exists());
+    }
+
+    #[test]
+    fn keeps_existing_destination_entries() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let old = tmp.path().join("dense-old");
+        std::fs::create_dir_all(&old).expect("mkdir");
+        std::fs::write(old.join("token"), "old").expect("seed");
+
+        let config_dir = tmp.path().join("dense-config");
+        std::fs::create_dir_all(&config_dir).expect("mkdir");
+        std::fs::write(config_dir.join("token"), "new").expect("seed");
+
+        let data_dir = tmp.path().join("dense-data");
+        move_entries(&old, &config_dir, &data_dir).expect("migrate");
+
+        assert_eq!(
+            std::fs::read_to_string(config_dir.join("token")).expect("read"),
+            "new"
+        );
+        // The conflicting old entry stays put, so the old dir survives too.
+        assert!(old.join("token").is_file());
+    }
+}


### PR DESCRIPTION
Resolve the unix dirs by the XDG base-dir rule on every non-Windows platform instead of via directories::BaseDirs, which on macOS dropped both config and data into ~/Library/Application Support/dense. Config now lives at ~/.config/dense, data at ~/.local/share/dense, honoring XDG_CONFIG_HOME / XDG_DATA_HOME; the binary stays at ~/.local/bin.

Existing macOS installs are migrated on first run: the old flat dir is sorted into the two new homes and the PATH env wiring in the shell profiles is rewritten to source the new env file location.