### PR TITLE
claude: assert first-party base url to keep 1M context window

### DIFF
--- a/src/harness/claude.rs
+++ b/src/harness/claude.rs
@@ -10,7 +10,11 @@ pub struct Claude;
 impl Tool<Anthropic> for Claude {
     fn apply(&self, cmd: &mut tokio::process::Command, target: &ProxyTarget) {
         cmd.env("ANTHROPIC_BASE_URL", &target.base_url)
-            .env("ANTHROPIC_CUSTOM_HEADERS", custom_headers(&target.headers));
+            .env("ANTHROPIC_CUSTOM_HEADERS", custom_headers(&target.headers))
+            // Claude Code disables the 1M context window when the base URL is
+            // not api.anthropic.com, silently falling back to 200K (compacts
+            // ~140K). Assert first-party so the 1M window stays on through us.
+            .env("_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL", "1");
     }
 
     fn binary(&self) -> &str {


### PR DESCRIPTION
Claude Code disables its 1M context window when ANTHROPIC_BASE_URL is not api.anthropic.com, silently reverting to a 200K budget and auto-compacting around 140K. Set _CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1 on the spawned process so routing through the condense proxy keeps the 1M window enabled.