### PR TITLE
feat(harness): route Codex through condense

### DIFF
--- a/src/api/dialect.rs
+++ b/src/api/dialect.rs
@@ -16,8 +16,16 @@ pub trait Dialect {
 
 pub struct Anthropic;
 
+pub struct OpenAi;
+
 impl Dialect for Anthropic {
     fn route(&self) -> &'static str {
         "anthropic"
+    }
+}
+
+impl Dialect for OpenAi {
+    fn route(&self) -> &'static str {
+        "openai"
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,7 +34,7 @@ pub enum Command {
         )]
         args: Vec<String>,
     },
-    /// Codex support (coming soon).
+    /// Launch Codex routed through condense.
     #[command(disable_help_flag = true)]
     Codex {
         #[arg(

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -6,6 +6,7 @@
 //! same for every tool and dialect.
 
 pub mod claude;
+pub mod codex;
 
 use std::process::Stdio;
 

--- a/src/harness/codex.rs
+++ b/src/harness/codex.rs
@@ -5,7 +5,6 @@ use crate::api::dialect::OpenAi;
 use crate::config::Config;
 use crate::harness::{self, ProxyTarget, Tool};
 
-const KEY_ENV_VAR: &str = "CONDENSE_CODEX_KEY";
 const PROVIDER_ID: &str = "condense";
 
 pub struct Codex;
@@ -28,18 +27,16 @@ impl Tool<OpenAi> for Codex {
         }
         let env_http_headers = format!("{{ {} }}", header_entries.join(", "));
 
-        // Real auth rides in x-condense-auth-token; the bearer is a placeholder
-        // the proxy replaces with the upstream key. requires_openai_auth=false
-        // drops Codex's `sk-` prefix assumption for the placeholder.
-        cmd.env(KEY_ENV_VAR, "condense");
-
+        // BYO upstream auth: requires_openai_auth=true makes Codex attach its own
+        // login (ChatGPT OAuth or an sk- key) as the bearer + chatgpt-account-id.
+        // The proxy forwards that to OpenAI (api.openai.com or, for OAuth, the
+        // codex backend); condense identity rides in the x-condense-* headers.
         let overrides = [
             format!(r#"model_provider="{PROVIDER_ID}""#),
             format!(r#"model_providers.{PROVIDER_ID}.name="condense""#),
             format!(r#"model_providers.{PROVIDER_ID}.base_url="{base_url}""#),
             format!(r#"model_providers.{PROVIDER_ID}.wire_api="responses""#),
-            format!("model_providers.{PROVIDER_ID}.requires_openai_auth=false"),
-            format!(r#"model_providers.{PROVIDER_ID}.env_key="{KEY_ENV_VAR}""#),
+            format!("model_providers.{PROVIDER_ID}.requires_openai_auth=true"),
             format!("model_providers.{PROVIDER_ID}.env_http_headers={env_http_headers}"),
         ];
         for o in overrides {
@@ -116,7 +113,7 @@ mod tests {
         ));
         assert!(argv.contains(r#"model_provider="condense""#));
         assert!(argv.contains(r#"model_providers.condense.wire_api="responses""#));
-        assert!(argv.contains("model_providers.condense.requires_openai_auth=false"));
+        assert!(argv.contains("model_providers.condense.requires_openai_auth=true"));
         // The header value rides in an env var referenced by env_http_headers —
         // never in argv.
         assert!(argv.contains("CONDENSE_HDR_X_CONDENSE_AUTH_TOKEN"));

--- a/src/harness/codex.rs
+++ b/src/harness/codex.rs
@@ -5,7 +5,9 @@ use crate::api::dialect::OpenAi;
 use crate::config::Config;
 use crate::harness::{self, ProxyTarget, Tool};
 
-const PROVIDER_ID: &str = "condense";
+// Dense-owned provider id, distinct from a hand-authored `[model_providers.condense]`:
+// `-c` overlays merge (can't delete) a stale block's keys, so we own a private id.
+const PROVIDER_ID: &str = "condense_cli";
 
 pub struct Codex;
 
@@ -109,11 +111,11 @@ mod tests {
         // Codex appends /responses to the provider base_url, so /v1 lands on
         // /openai/v1/responses.
         assert!(argv.contains(
-            r#"model_providers.condense.base_url="https://api.condense.chat/openai/v1""#
+            r#"model_providers.condense_cli.base_url="https://api.condense.chat/openai/v1""#
         ));
-        assert!(argv.contains(r#"model_provider="condense""#));
-        assert!(argv.contains(r#"model_providers.condense.wire_api="responses""#));
-        assert!(argv.contains("model_providers.condense.requires_openai_auth=true"));
+        assert!(argv.contains(r#"model_provider="condense_cli""#));
+        assert!(argv.contains(r#"model_providers.condense_cli.wire_api="responses""#));
+        assert!(argv.contains("model_providers.condense_cli.requires_openai_auth=true"));
         // The header value rides in an env var referenced by env_http_headers —
         // never in argv.
         assert!(argv.contains("CONDENSE_HDR_X_CONDENSE_AUTH_TOKEN"));

--- a/src/harness/codex.rs
+++ b/src/harness/codex.rs
@@ -1,0 +1,130 @@
+//! Codex through condense — `Codex<OpenAi>`.
+
+use crate::Result;
+use crate::api::dialect::OpenAi;
+use crate::config::Config;
+use crate::harness::{self, ProxyTarget, Tool};
+
+const KEY_ENV_VAR: &str = "CONDENSE_CODEX_KEY";
+const PROVIDER_ID: &str = "condense";
+
+pub struct Codex;
+
+impl Tool<OpenAi> for Codex {
+    /// Codex has no single custom-headers env var, so the provider is defined
+    /// inline via `-c` overrides (top of the precedence stack, untouched by the
+    /// project-config security boundary). Secret header values ride in env vars
+    /// referenced by `env_http_headers`, never in argv.
+    fn apply(&self, cmd: &mut tokio::process::Command, target: &ProxyTarget) {
+        // The dialect base is `<api>/openai`; Codex appends `/responses` to the
+        // provider base_url, so the `/v1` lands us on `/openai/v1/responses`.
+        let base_url = format!("{}/v1", target.base_url);
+
+        let mut header_entries: Vec<String> = Vec::new();
+        for (name, value) in &target.headers {
+            let env_name = header_env_var(name);
+            cmd.env(&env_name, value);
+            header_entries.push(format!("{name:?} = {env_name:?}"));
+        }
+        let env_http_headers = format!("{{ {} }}", header_entries.join(", "));
+
+        // Real auth rides in x-condense-auth-token; the bearer is a placeholder
+        // the proxy replaces with the upstream key. requires_openai_auth=false
+        // drops Codex's `sk-` prefix assumption for the placeholder.
+        cmd.env(KEY_ENV_VAR, "condense");
+
+        let overrides = [
+            format!(r#"model_provider="{PROVIDER_ID}""#),
+            format!(r#"model_providers.{PROVIDER_ID}.name="condense""#),
+            format!(r#"model_providers.{PROVIDER_ID}.base_url="{base_url}""#),
+            format!(r#"model_providers.{PROVIDER_ID}.wire_api="responses""#),
+            format!("model_providers.{PROVIDER_ID}.requires_openai_auth=false"),
+            format!(r#"model_providers.{PROVIDER_ID}.env_key="{KEY_ENV_VAR}""#),
+            format!("model_providers.{PROVIDER_ID}.env_http_headers={env_http_headers}"),
+        ];
+        for o in overrides {
+            cmd.arg("-c").arg(o);
+        }
+    }
+
+    fn binary(&self) -> &str {
+        "codex"
+    }
+
+    fn label(&self) -> &str {
+        "Codex"
+    }
+}
+
+/// `dense codex` — Codex through the OpenAI Responses proxy. The dialect is the
+/// concrete `OpenAi`, so no proxy flag is threaded through the run path.
+pub async fn run(cfg: &Config, args: &[String]) -> Result<()> {
+    harness::launch(cfg, Codex, OpenAi, args).await
+}
+
+/// Per-header env var name holding the secret value; the `env_http_headers` map
+/// references these names so secrets never land in argv.
+fn header_env_var(name: &str) -> String {
+    let suffix: String = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_uppercase()
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    format!("CONDENSE_HDR_{suffix}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_env_var_sanitises_name() {
+        assert_eq!(
+            header_env_var("x-condense-auth-token"),
+            "CONDENSE_HDR_X_CONDENSE_AUTH_TOKEN"
+        );
+    }
+
+    #[test]
+    fn apply_builds_provider_overrides_and_keeps_secrets_out_of_argv() {
+        let target = ProxyTarget {
+            base_url: "https://api.condense.chat/openai".to_string(),
+            headers: vec![(
+                "x-condense-auth-token".to_string(),
+                "secret-token".to_string(),
+            )],
+        };
+        let mut cmd = tokio::process::Command::new("codex");
+        Codex.apply(&mut cmd, &target);
+
+        let std_cmd = cmd.as_std();
+        let args: Vec<String> = std_cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        let argv = args.join(" ");
+
+        // Codex appends /responses to the provider base_url, so /v1 lands on
+        // /openai/v1/responses.
+        assert!(argv.contains(
+            r#"model_providers.condense.base_url="https://api.condense.chat/openai/v1""#
+        ));
+        assert!(argv.contains(r#"model_provider="condense""#));
+        assert!(argv.contains(r#"model_providers.condense.wire_api="responses""#));
+        assert!(argv.contains("model_providers.condense.requires_openai_auth=false"));
+        // The header value rides in an env var referenced by env_http_headers —
+        // never in argv.
+        assert!(argv.contains("CONDENSE_HDR_X_CONDENSE_AUTH_TOKEN"));
+        assert!(!argv.contains("secret-token"));
+
+        let has_secret_env = std_cmd.get_envs().any(|(k, v)| {
+            k == "CONDENSE_HDR_X_CONDENSE_AUTH_TOKEN" && v == Some("secret-token".as_ref())
+        });
+        assert!(has_secret_env);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,10 +57,7 @@ async fn main() -> EyreResult<()> {
             status(&cfg);
             Ok(())
         }
-        Command::Codex { .. } => {
-            println!("Codex support is coming soon.");
-            Ok(())
-        }
+        Command::Codex { args } => harness::codex::run(&cfg, &args).await,
         Command::Login => auth::login(&cfg).await,
         Command::Logout => auth::logout(&cfg),
         Command::Claude { args } => harness::claude::run(&cfg, &args).await,

--- a/src/persist.rs
+++ b/src/persist.rs
@@ -21,7 +21,7 @@ const TOOLS: &[ToolSpec] = &[
     },
     ToolSpec {
         name: "codex",
-        available: false,
+        available: true,
         install_hint: "",
     },
 ];


### PR DESCRIPTION
## What

Adds `dense codex` — routes the OpenAI **Codex** CLI through the condense
proxy, the way `dense claude` already routes Claude Code. First OpenAI-dialect
tool in the harness.

## How

- **New `OpenAi` dialect** (`route() = "openai"`) alongside `Anthropic`.
- **`Codex<OpenAi>` tool** (`src/harness/codex.rs`) reusing the generic
  `harness::launch` lifecycle (auth → session → spawn → heartbeat).
- Codex has no `OPENAI_CUSTOM_HEADERS` analog, so the provider is injected via
  **`-c` config overrides** on the codex argv — no files written, the user's
  `~/.codex` is left untouched (mirrors the Claude harness's env-only model):
  - `model_provider`, `base_url` (`…/openai/v1` → codex appends `/responses`),
    `wire_api="responses"`, `requires_openai_auth=true`.
  - `x-condense-*` identity/secret values ride in **`env_http_headers` env
    vars**, never in argv (a unit test asserts the token stays out of `argv`).
- **BYO upstream auth**: `requires_openai_auth=true` lets codex attach its *own*
  credential (ChatGPT OAuth **or** an `sk-` key) — dense no longer injects a
  placeholder. The proxy-side routing that sends a ChatGPT login to the codex
  backend vs. `sk-` keys to the public API lives in the condense superproject,
  not here.
- **Collision-proof provider id `condense_cli`**: a `-c` overlay can only merge
  onto a same-named `[model_providers.condense]` block, never delete its stale
  keys — so a hand-authored block would shadow ours. A dense-owned id sidesteps
  it entirely (display name still reads "condense").

## Commits

- `feat(harness): route Codex through condense`
- `fix(codex): BYO upstream auth — let codex attach its own credential`
- `fix(codex): use collision-proof provider id condense_cli`

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test`
  all green (27 tests, incl. the `-c` wire-contract + secret-redaction tests).
- Real round-trip through a local condense proxy: ChatGPT-logged-in codex →
  forwarded to the codex backend → turn persisted, **zero errors**.

## Depends on

The matching condense proxy support for `/openai/v1/responses` (SSE + WS) — must
be deployed for this to have an endpoint to talk to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
