### PR TITLE
feat: route `claude agents` through condense + post-install doctor & agent fix

### DIFF
--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,11 +1,14 @@
 //! `dense doctor` — verify the install is wired correctly and report a
 //! status table. Reports only; it never mutates state.
 
-use std::path::Path;
-
 use crate::api::auth;
 use crate::config::Config;
 use crate::{Result, persist, tool, ui};
+
+/// Lowest Claude Code that honors `_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL`
+/// (the harness's lever for the 1M context window behind the proxy). Older
+/// builds silently fall back to the 200K window.
+const MIN_CLAUDE_VERSION: (u32, u32, u32) = (2, 1, 169);
 
 /// A check's outcome. `Fail` is a critical wiring problem an agent could repair;
 /// `Warn` is a transient/environmental note (PATH not reloaded, not logged in)
@@ -33,22 +36,20 @@ impl Check {
 /// Run every check and return the results without printing — the structured
 /// view [`run`] and setup share.
 pub async fn diagnose(cfg: &Config) -> Vec<Check> {
-    let mut checks = vec![
-        soft(on_path("dense"), "dense on PATH", ""),
-        soft(
-            path_contains(&cfg.shim_dir()),
-            "override dir on PATH",
-            &cfg.shim_dir().display().to_string(),
-        ),
-        check(
-            cfg.env_file().exists(),
-            "env file present",
-            &cfg.env_file().display().to_string(),
-        ),
-    ];
+    let mut checks = vec![check(
+        cfg.env_file().exists(),
+        "env file present",
+        &cfg.env_file().display().to_string(),
+    )];
+    checks.extend(new_shell_checks(cfg));
 
     match tool::resolve_real(cfg, "claude") {
-        Ok(p) => checks.push(check(true, "claude detected", &p.display().to_string())),
+        Ok(p) => {
+            checks.push(check(true, "claude detected", &p.display().to_string()));
+            if let Some(v) = claude_version_check(&p) {
+                checks.push(v);
+            }
+        }
         Err(_) => checks.push(warn(
             "claude detected",
             "not found — https://docs.claude.com/en/docs/claude-code",
@@ -111,22 +112,59 @@ fn check(ok: bool, label: &str, detail: &str) -> Check {
     }
 }
 
-fn on_path(name: &str) -> bool {
-    path_dirs().iter().any(|d| {
-        d.join(name).is_file()
-            || d.join(format!("{name}.exe")).is_file()
-            || d.join(format!("{name}.cmd")).is_file()
-    })
+/// Whether a freshly-started shell actually has the dense dirs on PATH — the
+/// failure users miss most: the install looks fine, but a new terminal still
+/// runs the system `claude`, silently bypassing condense. We start the user's
+/// `$SHELL` as a login+interactive session (sourcing the same profiles a new
+/// terminal would) and inspect the PATH it ends up with.
+fn new_shell_checks(cfg: &Config) -> Vec<Check> {
+    let Some(paths) = new_session_path() else {
+        return vec![warn(
+            "new-shell PATH",
+            "couldn't start your shell to verify a new session",
+        )];
+    };
+    let mut out = vec![check(
+        paths.iter().any(|d| d == &cfg.bin_dir()),
+        "dense on PATH in a new shell",
+        &cfg.bin_dir().display().to_string(),
+    )];
+    if shim_installed(cfg, "claude") {
+        out.push(check(
+            paths.iter().any(|d| d == &cfg.shim_dir()),
+            "claude routes via dense in a new shell",
+            &cfg.shim_dir().display().to_string(),
+        ));
+    }
+    out
 }
 
-fn path_contains(dir: &Path) -> bool {
-    path_dirs().iter().any(|d| d == dir)
+/// The PATH a brand-new login+interactive shell sees, or `None` if we couldn't
+/// capture it. The output is bracketed by sentinels so profile/MOTD noise on
+/// stdout doesn't corrupt the parse.
+#[cfg(not(windows))]
+fn new_session_path() -> Option<Vec<std::path::PathBuf>> {
+    const OPEN: &str = "__DENSE_PATH__";
+    const CLOSE: &str = "__DENSE_END__";
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+    let probe = format!("printf '{OPEN}%s{CLOSE}' \"$PATH\"");
+    let out = std::process::Command::new(&shell)
+        .args(["-l", "-i", "-c", &probe])
+        .stdin(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let start = stdout.find(OPEN)? + OPEN.len();
+    let rest = &stdout[start..];
+    let end = rest.find(CLOSE)?;
+    let path = &rest[..end];
+    (!path.is_empty()).then(|| std::env::split_paths(path).collect())
 }
 
-fn path_dirs() -> Vec<std::path::PathBuf> {
-    std::env::var_os("PATH")
-        .map(|p| std::env::split_paths(&p).collect())
-        .unwrap_or_default()
+#[cfg(windows)]
+fn new_session_path() -> Option<Vec<std::path::PathBuf>> {
+    std::env::var_os("PATH").map(|p| std::env::split_paths(&p).collect())
 }
 
 fn print_row(mark: &str, label: &str, detail: &str) {
@@ -135,6 +173,44 @@ fn print_row(mark: &str, label: &str, detail: &str) {
     } else {
         println!("  {mark} {label}  {}", ui::dim(&format!("({detail})")));
     }
+}
+
+/// Warn when the installed Claude Code predates [`MIN_CLAUDE_VERSION`]: the
+/// harness can't force the 1M window on it, so the user silently gets the 200K
+/// one. `None` (no row) if `claude --version` can't be read or parsed.
+fn claude_version_check(claude: &std::path::Path) -> Option<Check> {
+    let out = std::process::Command::new(claude)
+        .arg("--version")
+        .output()
+        .ok()?;
+    let ver = parse_version(&String::from_utf8_lossy(&out.stdout))?;
+    let shown = format!("{}.{}.{}", ver.0, ver.1, ver.2);
+    if ver >= MIN_CLAUDE_VERSION {
+        Some(check(true, "claude gets condense's 1M context", &shown))
+    } else {
+        let (a, b, c) = MIN_CLAUDE_VERSION;
+        Some(warn(
+            "claude gets condense's 1M context",
+            &format!("{shown} < {a}.{b}.{c} — likely the 200K window; upgrade Claude Code"),
+        ))
+    }
+}
+
+/// First `MAJOR.MINOR.PATCH` in `claude --version` output (e.g.
+/// "2.1.177 (Claude Code)"), tolerant of surrounding text.
+fn parse_version(text: &str) -> Option<(u32, u32, u32)> {
+    text.split(|c: char| !c.is_ascii_digit() && c != '.')
+        .find_map(|tok| {
+            let mut parts = tok.split('.');
+            let major = parts.next()?.parse().ok()?;
+            let minor = parts.next()?.parse().ok()?;
+            let patch = parts.next()?.parse().ok()?;
+            Some((major, minor, patch))
+        })
+}
+
+fn shim_installed(cfg: &Config, name: &str) -> bool {
+    persist::load_record(cfg).tools.contains_key(name)
 }
 
 /// A non-critical check: green when satisfied, a yellow warn otherwise.
@@ -151,5 +227,27 @@ fn warn(label: &str, detail: &str) -> Check {
         detail: detail.to_string(),
         health: Health::Warn,
         label: label.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_version_tolerates_trailing_text() {
+        assert_eq!(parse_version("2.1.177 (Claude Code)"), Some((2, 1, 177)));
+        assert_eq!(parse_version("v2.1.169"), Some((2, 1, 169)));
+        assert_eq!(parse_version("Claude Code 2.0.5"), Some((2, 0, 5)));
+        assert_eq!(parse_version("no version here"), None);
+    }
+
+    #[test]
+    fn min_version_is_an_inclusive_floor() {
+        assert!((2, 1, 169) >= MIN_CLAUDE_VERSION);
+        assert!((2, 1, 177) >= MIN_CLAUDE_VERSION);
+        assert!((2, 2, 0) >= MIN_CLAUDE_VERSION);
+        assert!((2, 1, 168) < MIN_CLAUDE_VERSION);
+        assert!((2, 0, 999) < MIN_CLAUDE_VERSION);
     }
 }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -7,66 +7,107 @@ use crate::api::auth;
 use crate::config::Config;
 use crate::{Result, persist, tool, ui};
 
-pub async fn run(cfg: &Config) -> Result<()> {
+/// A check's outcome. `Warn`/`Fail` both count as issues a caller (e.g. setup's
+/// offer-to-fix) may act on; only the rendered mark differs.
+pub enum Health {
+    Fail,
+    Ok,
+    Warn,
+}
+
+/// One row of the doctor report, kept structured so callers other than the
+/// printed table can see what failed.
+pub struct Check {
+    pub detail: String,
+    pub health: Health,
+    pub label: String,
+}
+
+impl Check {
+    pub fn is_issue(&self) -> bool {
+        !matches!(self.health, Health::Ok)
+    }
+}
+
+/// Run every check and return the results without printing — the structured
+/// view [`run`] and setup share.
+pub async fn diagnose(cfg: &Config) -> Vec<Check> {
+    let mut checks = vec![
+        check(on_path("dense"), "dense on PATH", ""),
+        check(
+            path_contains(&cfg.shim_dir()),
+            "override dir on PATH",
+            &cfg.shim_dir().display().to_string(),
+        ),
+        check(
+            cfg.env_file().exists(),
+            "env file present",
+            &cfg.env_file().display().to_string(),
+        ),
+    ];
+
+    match tool::resolve_real(cfg, "claude") {
+        Ok(p) => checks.push(check(true, "claude detected", &p.display().to_string())),
+        Err(_) => checks.push(warn(
+            "claude detected",
+            "not found — https://docs.claude.com/en/docs/claude-code",
+        )),
+    }
+
+    let creds = auth::load_creds(cfg);
+    checks.push(check(
+        creds.is_authenticated(),
+        "authenticated",
+        &cfg.cred_dir().display().to_string(),
+    ));
+    if let Some(token) = creds.token.as_deref() {
+        let status = auth::probe_token(cfg, token).await;
+        checks.push(check(
+            status == 200,
+            "token valid (/v1/me)",
+            &format!("status {status}"),
+        ));
+    }
+
+    for name in persist::load_record(cfg).tools.keys() {
+        let path = persist::shim_path(cfg, name);
+        checks.push(check(
+            path.exists(),
+            &format!("shim: {name}"),
+            &path.display().to_string(),
+        ));
+    }
+    checks
+}
+
+/// Render a diagnosed report as the familiar status table.
+pub fn print_report(cfg: &Config, checks: &[Check]) {
     println!(
         "{} {}\n",
         ui::bold("dense doctor —"),
         ui::dim(&cfg.api_base_url)
     );
-
-    line(on_path("dense"), "dense on PATH", "");
-    line(
-        path_contains(&cfg.shim_dir()),
-        "override dir on PATH",
-        &cfg.shim_dir().display().to_string(),
-    );
-    line(
-        cfg.env_file().exists(),
-        "env file present",
-        &cfg.env_file().display().to_string(),
-    );
-
-    match tool::resolve_real(cfg, "claude") {
-        Ok(p) => line(true, "claude detected", &p.display().to_string()),
-        Err(_) => warn(
-            "claude detected",
-            "not found — https://docs.claude.com/en/docs/claude-code",
-        ),
+    for c in checks {
+        let mark = match c.health {
+            Health::Ok => ui::green("\u{2713}"),
+            Health::Warn => ui::yellow("!"),
+            Health::Fail => ui::red("\u{2717}"),
+        };
+        print_row(&mark, &c.label, &c.detail);
     }
+}
 
-    let creds = auth::load_creds(cfg);
-    line(
-        creds.is_authenticated(),
-        "authenticated",
-        &cfg.cred_dir().display().to_string(),
-    );
-    if let Some(token) = creds.token.as_deref() {
-        let status = auth::probe_token(cfg, token).await;
-        line(
-            status == 200,
-            "token valid (/v1/me)",
-            &format!("status {status}"),
-        );
-    }
-
-    for name in persist::load_record(cfg).tools.keys() {
-        let path = persist::shim_path(cfg, name);
-        line(
-            path.exists(),
-            &format!("shim: {name}"),
-            &path.display().to_string(),
-        );
-    }
+pub async fn run(cfg: &Config) -> Result<()> {
+    print_report(cfg, &diagnose(cfg).await);
     Ok(())
 }
 
-fn line(ok: bool, label: &str, detail: &str) {
-    let mark = if ok {
-        ui::green("\u{2713}")
-    } else {
-        ui::red("\u{2717}")
-    };
-    print_row(&mark, label, detail);
+fn check(ok: bool, label: &str, detail: &str) -> Check {
+    Check {
+        detail: detail.to_string(),
+        health: if ok { Health::Ok } else { Health::Fail },
+        label: label.to_string(),
+    }
 }
 
 fn on_path(name: &str) -> bool {
@@ -95,6 +136,10 @@ fn print_row(mark: &str, label: &str, detail: &str) {
     }
 }
 
-fn warn(label: &str, detail: &str) {
-    print_row(&ui::yellow("!"), label, detail);
+fn warn(label: &str, detail: &str) -> Check {
+    Check {
+        detail: detail.to_string(),
+        health: Health::Warn,
+        label: label.to_string(),
+    }
 }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -7,8 +7,9 @@ use crate::api::auth;
 use crate::config::Config;
 use crate::{Result, persist, tool, ui};
 
-/// A check's outcome. `Warn`/`Fail` both count as issues a caller (e.g. setup's
-/// offer-to-fix) may act on; only the rendered mark differs.
+/// A check's outcome. `Fail` is a critical wiring problem an agent could repair;
+/// `Warn` is a transient/environmental note (PATH not reloaded, not logged in)
+/// that shouldn't block. Only the rendered mark differs.
 pub enum Health {
     Fail,
     Ok,
@@ -24,8 +25,8 @@ pub struct Check {
 }
 
 impl Check {
-    pub fn is_issue(&self) -> bool {
-        !matches!(self.health, Health::Ok)
+    pub fn is_critical(&self) -> bool {
+        matches!(self.health, Health::Fail)
     }
 }
 
@@ -33,8 +34,8 @@ impl Check {
 /// view [`run`] and setup share.
 pub async fn diagnose(cfg: &Config) -> Vec<Check> {
     let mut checks = vec![
-        check(on_path("dense"), "dense on PATH", ""),
-        check(
+        soft(on_path("dense"), "dense on PATH", ""),
+        soft(
             path_contains(&cfg.shim_dir()),
             "override dir on PATH",
             &cfg.shim_dir().display().to_string(),
@@ -55,14 +56,14 @@ pub async fn diagnose(cfg: &Config) -> Vec<Check> {
     }
 
     let creds = auth::load_creds(cfg);
-    checks.push(check(
+    checks.push(soft(
         creds.is_authenticated(),
         "authenticated",
         &cfg.cred_dir().display().to_string(),
     ));
     if let Some(token) = creds.token.as_deref() {
         let status = auth::probe_token(cfg, token).await;
-        checks.push(check(
+        checks.push(soft(
             status == 200,
             "token valid (/v1/me)",
             &format!("status {status}"),
@@ -133,6 +134,15 @@ fn print_row(mark: &str, label: &str, detail: &str) {
         println!("  {mark} {label}");
     } else {
         println!("  {mark} {label}  {}", ui::dim(&format!("({detail})")));
+    }
+}
+
+/// A non-critical check: green when satisfied, a yellow warn otherwise.
+fn soft(ok: bool, label: &str, detail: &str) -> Check {
+    Check {
+        detail: detail.to_string(),
+        health: if ok { Health::Ok } else { Health::Warn },
+        label: label.to_string(),
     }
 }
 

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -26,6 +26,13 @@ pub trait Tool<D: Dialect> {
 
     fn binary(&self) -> &str;
     fn label(&self) -> &str;
+
+    /// Optionally rewrite the child's argv given `target` — e.g. weave the route
+    /// into a flag so sessions the tool itself dispatches inherit it. Default:
+    /// argv unchanged.
+    fn rewrite_args(&self, args: &[String], _target: &ProxyTarget) -> Vec<String> {
+        args.to_vec()
+    }
 }
 
 /// A resolved proxy target a tool wires itself to.
@@ -57,7 +64,8 @@ where
 
     let mut cmd = tokio::process::Command::new(&bin);
     tool.apply(&mut cmd, &target);
-    cmd.args(args)
+    let args = tool.rewrite_args(args, &target);
+    cmd.args(&args)
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(Stdio::inherit());

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -33,6 +33,13 @@ pub trait Tool<D: Dialect> {
     fn rewrite_args(&self, args: &[String], _target: &ProxyTarget) -> Vec<String> {
         args.to_vec()
     }
+
+    /// An upstream the proxy should route to, read from the tool's own
+    /// passthrough env (e.g. a pre-set `ANTHROPIC_BASE_URL`). Lower precedence
+    /// than the explicit `CONDENSE_UPSTREAM_URL`. Default: none.
+    fn upstream_override(&self) -> Option<String> {
+        None
+    }
 }
 
 /// A resolved proxy target a tool wires itself to.
@@ -57,9 +64,13 @@ where
         announce(cfg, tool.label());
     }
 
+    let upstream = cfg
+        .upstream()
+        .map(str::to_string)
+        .or_else(|| tool.upstream_override());
     let target = ProxyTarget {
         base_url: dialect.base_url(cfg),
-        headers: condense_headers(cfg, &creds, &session.id),
+        headers: condense_headers(&creds, &session.id, upstream.as_deref()),
     };
 
     let mut cmd = tokio::process::Command::new(&bin);
@@ -100,8 +111,13 @@ fn announce(cfg: &Config, label: &str) {
 }
 
 /// The `x-condense-*` headers on every request — auth/user/session, plus the
-/// optional upstream override. Universal; the upstream comes from [`Config`].
-fn condense_headers(cfg: &Config, creds: &Creds, session_id: &str) -> Vec<(String, String)> {
+/// optional upstream override (explicit `CONDENSE_UPSTREAM_URL`, else a tool's
+/// inherited base URL). Universal across tools and dialects.
+fn condense_headers(
+    creds: &Creds,
+    session_id: &str,
+    upstream: Option<&str>,
+) -> Vec<(String, String)> {
     let mut h = Vec::new();
     if let Some(token) = &creds.token {
         h.push(("x-condense-auth-token".to_string(), token.clone()));
@@ -110,7 +126,7 @@ fn condense_headers(cfg: &Config, creds: &Creds, session_id: &str) -> Vec<(Strin
         h.push(("x-condense-user-id".to_string(), user.clone()));
     }
     h.push(("x-condense-session-id".to_string(), session_id.to_string()));
-    if let Some(upstream) = cfg.upstream() {
+    if let Some(upstream) = upstream {
         h.push(("x-condense-upstream-url".to_string(), upstream.to_string()));
     }
     h
@@ -140,4 +156,25 @@ fn swallow_interrupts() -> tokio::task::JoinHandle<()> {
             let _ = tokio::signal::ctrl_c().await;
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upstream_header_present_only_when_set() {
+        let creds = Creds {
+            token: None,
+            user_id: None,
+        };
+        let with = condense_headers(&creds, "sid", Some("https://up"));
+        assert!(
+            with.iter()
+                .any(|(k, v)| k == "x-condense-upstream-url" && v == "https://up")
+        );
+
+        let without = condense_headers(&creds, "sid", None);
+        assert!(without.iter().all(|(k, _)| k != "x-condense-upstream-url"));
+    }
 }

--- a/src/harness/claude.rs
+++ b/src/harness/claude.rs
@@ -62,6 +62,16 @@ impl Tool<Anthropic> for Claude {
             }
         }
     }
+
+    /// A base URL the user set before launching points the proxy at their own
+    /// upstream — we overwrite `ANTHROPIC_BASE_URL` with the condense route, so
+    /// forward the original as the upstream override.
+    fn upstream_override(&self) -> Option<String> {
+        std::env::var("ANTHROPIC_BASE_URL")
+            .ok()
+            .map(|u| u.trim().to_string())
+            .filter(|u| !u.is_empty())
+    }
 }
 
 /// `dense claude` — Claude Code through the Anthropic proxy. The dialect is the

--- a/src/harness/claude.rs
+++ b/src/harness/claude.rs
@@ -3,9 +3,17 @@
 use crate::Result;
 use crate::api::dialect::Anthropic;
 use crate::config::Config;
+use crate::error::{Context, Error};
 use crate::harness::{self, ProxyTarget, Tool};
 
 pub struct Claude;
+
+/// Which `--settings` form a `claude agents` invocation used, so the merged
+/// value lands back in the right argv slot.
+enum SettingsRef {
+    Inline { token: usize },
+    Separate { flag: usize },
+}
 
 impl Tool<Anthropic> for Claude {
     fn apply(&self, cmd: &mut tokio::process::Command, target: &ProxyTarget) {
@@ -33,6 +41,27 @@ impl Tool<Anthropic> for Claude {
     fn label(&self) -> &str {
         "Claude Code"
     }
+
+    /// `claude agents` dispatches background sessions whose env is stripped of
+    /// `ANTHROPIC_BASE_URL`/`ANTHROPIC_CUSTOM_HEADERS`, so they only reach the
+    /// proxy if the route rides in a `--settings` env block the agent view
+    /// threads down. For that subcommand, merge ours in; leave every other
+    /// invocation untouched.
+    fn rewrite_args(&self, args: &[String], target: &ProxyTarget) -> Vec<String> {
+        if args.first().map(String::as_str) != Some("agents") {
+            return args.to_vec();
+        }
+        match merge_agents_settings(args, &target.base_url, &target.headers) {
+            Ok(rewritten) => rewritten,
+            Err(e) => {
+                eprintln!(
+                    "dense: leaving `claude agents --settings` as-is ({e}); \
+                     dispatched agents may not route through condense"
+                );
+                args.to_vec()
+            }
+        }
+    }
 }
 
 /// `dense claude` — Claude Code through the Anthropic proxy. The dialect is the
@@ -44,6 +73,82 @@ pub async fn run(cfg: &Config, args: &[String]) -> Result<()> {
 fn custom_headers(headers: &[(String, String)]) -> String {
     let existing = std::env::var("ANTHROPIC_CUSTOM_HEADERS").ok();
     merge_headers(existing.as_deref(), headers)
+}
+
+/// A `--settings` value is either an inline JSON object or a path to a JSON
+/// file. Parse whichever it is into a value we can merge into.
+fn load_settings(raw: &str) -> Result<serde_json::Value> {
+    if raw.trim_start().starts_with('{') {
+        serde_json::from_str(raw).ctx("parse --settings JSON")
+    } else {
+        let body = std::fs::read_to_string(raw).ctx(format!("read --settings file {raw}"))?;
+        serde_json::from_str(&body).ctx(format!("parse --settings file {raw}"))
+    }
+}
+
+/// Fold our route into the agent invocation's `--settings` `env` block —
+/// reusing the existing one (inline or file) and keeping the user's keys, or
+/// appending a fresh `--settings` when there is none. `ANTHROPIC_BASE_URL` is
+/// ours; `ANTHROPIC_CUSTOM_HEADERS` merges through [`merge_headers`].
+fn merge_agents_settings(
+    args: &[String],
+    base_url: &str,
+    headers: &[(String, String)],
+) -> Result<Vec<String>> {
+    let mut found = None;
+    for (i, arg) in args.iter().enumerate() {
+        if arg == "--settings" {
+            found = Some(SettingsRef::Separate { flag: i });
+        } else if arg.starts_with("--settings=") {
+            found = Some(SettingsRef::Inline { token: i });
+        }
+    }
+
+    let existing = match &found {
+        Some(SettingsRef::Inline { token }) => {
+            args[*token].strip_prefix("--settings=").map(str::to_string)
+        }
+        Some(SettingsRef::Separate { flag }) => args.get(flag + 1).cloned(),
+        None => None,
+    };
+
+    let mut settings = match existing.as_deref() {
+        Some(raw) => load_settings(raw)?,
+        None => serde_json::json!({}),
+    };
+    let env = settings
+        .as_object_mut()
+        .ok_or_else(|| Error::msg("--settings is not a JSON object"))?
+        .entry("env")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .ok_or_else(|| Error::msg("settings `env` is not a JSON object"))?;
+    let merged_headers = merge_headers(
+        env.get("ANTHROPIC_CUSTOM_HEADERS")
+            .and_then(serde_json::Value::as_str),
+        headers,
+    );
+    env.insert(
+        "ANTHROPIC_BASE_URL".to_string(),
+        serde_json::Value::String(base_url.to_string()),
+    );
+    env.insert(
+        "ANTHROPIC_CUSTOM_HEADERS".to_string(),
+        serde_json::Value::String(merged_headers),
+    );
+    let value = serde_json::to_string(&settings).ctx("serialize merged --settings")?;
+
+    let mut out = args.to_vec();
+    match found {
+        Some(SettingsRef::Inline { token }) => out[token] = format!("--settings={value}"),
+        Some(SettingsRef::Separate { flag }) if flag + 1 < out.len() => out[flag + 1] = value,
+        Some(SettingsRef::Separate { .. }) => out.push(value),
+        None => {
+            out.push("--settings".to_string());
+            out.push(value);
+        }
+    }
+    Ok(out)
 }
 
 /// Newline-joined `Name: Value` for ANTHROPIC_CUSTOM_HEADERS. Preserves a
@@ -88,5 +193,66 @@ mod tests {
     fn merge_without_existing_is_just_ours() {
         let ours = vec![("x-condense-user-id".to_string(), "u".to_string())];
         assert_eq!(merge_headers(None, &ours), "x-condense-user-id: u");
+    }
+
+    #[test]
+    fn non_agents_argv_is_untouched() {
+        let target = ProxyTarget {
+            base_url: "https://api/anthropic".to_string(),
+            headers: vec![],
+        };
+        let args = vec!["--print".to_string(), "hi".to_string()];
+        assert_eq!(Claude.rewrite_args(&args, &target), args);
+    }
+
+    #[test]
+    fn agents_without_settings_appends_env_block() {
+        let headers = vec![("x-condense-user-id".to_string(), "u".to_string())];
+        let args = vec!["agents".to_string(), "--cwd".to_string(), "/x".to_string()];
+        let out = merge_agents_settings(&args, "https://api/anthropic", &headers).unwrap();
+        assert_eq!(out[..3], args[..]);
+        assert_eq!(out[3], "--settings");
+        let v: serde_json::Value = serde_json::from_str(&out[4]).unwrap();
+        assert_eq!(v["env"]["ANTHROPIC_BASE_URL"], "https://api/anthropic");
+        assert_eq!(
+            v["env"]["ANTHROPIC_CUSTOM_HEADERS"],
+            "x-condense-user-id: u"
+        );
+    }
+
+    #[test]
+    fn agents_merges_into_inline_settings_keeping_user_keys() {
+        let headers = vec![("x-condense-session-id".to_string(), "s".to_string())];
+        let args = vec![
+            "agents".to_string(),
+            "--settings={\"model\":\"opus\",\"env\":{\"FOO\":\"bar\"}}".to_string(),
+        ];
+        let out = merge_agents_settings(&args, "https://api/anthropic", &headers).unwrap();
+        let raw = out[1].strip_prefix("--settings=").unwrap();
+        let v: serde_json::Value = serde_json::from_str(raw).unwrap();
+        assert_eq!(v["model"], "opus");
+        assert_eq!(v["env"]["FOO"], "bar");
+        assert_eq!(v["env"]["ANTHROPIC_BASE_URL"], "https://api/anthropic");
+        assert_eq!(
+            v["env"]["ANTHROPIC_CUSTOM_HEADERS"],
+            "x-condense-session-id: s"
+        );
+    }
+
+    #[test]
+    fn agents_merges_separate_settings_value_and_combines_headers() {
+        let headers = vec![("x-condense-user-id".to_string(), "u".to_string())];
+        let args = vec![
+            "agents".to_string(),
+            "--settings".to_string(),
+            "{\"env\":{\"ANTHROPIC_CUSTOM_HEADERS\":\"x-user: keep\"}}".to_string(),
+        ];
+        let out = merge_agents_settings(&args, "https://b", &headers).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out[2]).unwrap();
+        assert_eq!(v["env"]["ANTHROPIC_BASE_URL"], "https://b");
+        assert_eq!(
+            v["env"]["ANTHROPIC_CUSTOM_HEADERS"],
+            "x-user: keep\nx-condense-user-id: u"
+        );
     }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -11,9 +11,17 @@ use crate::config::Config;
 use crate::error::Error;
 use crate::{Result, doctor, env_file, harness, persist, tool, ui};
 
-/// Coding agents `dense` can launch to repair a broken install. Only those with
-/// a harness run path belong here; setup offers the ones actually installed.
-const FIX_AGENTS: &[&str] = &["claude"];
+/// Coding agents `dense` can launch through its harness. Only those with a
+/// harness run path belong here; setup offers the ones actually installed.
+const LAUNCH_AGENTS: &[&str] = &["claude"];
+
+/// Why we're offering to launch an agent at the end of setup: to repair
+/// critical wiring issues, or just to start using the tool now.
+#[derive(Clone, Copy)]
+enum LaunchKind {
+    Fix,
+    Now,
+}
 
 pub async fn run(cfg: &Config) -> Result<()> {
     let interactive = std::io::stdin().is_terminal();
@@ -24,25 +32,28 @@ pub async fn run(cfg: &Config) -> Result<()> {
         }
         return res;
     }
-    offer_fix(cfg, interactive).await
+    offer_launch(cfg, interactive).await
 }
 
 fn available_agents(cfg: &Config) -> Vec<&'static str> {
-    FIX_AGENTS
+    LAUNCH_AGENTS
         .iter()
         .copied()
         .filter(|name| tool::resolve_real(cfg, name).is_ok())
         .collect()
 }
 
-/// Ask which installed agent (if any) should fix the issues. One agent is a
-/// yes/no; several is a pick-or-skip select. `None` = leave it alone.
-fn choose_agent(agents: &[&'static str]) -> Option<&'static str> {
+/// Ask which installed agent (if any) to launch. One agent is a yes/no; several
+/// is a pick-or-skip select. The wording follows `kind`. `None` = leave it.
+fn choose_agent(agents: &[&'static str], kind: LaunchKind) -> Option<&'static str> {
     match agents {
         [] => None,
         [only] => {
-            let _ = cliclack::log::warning("dense found setup issues above.");
-            cliclack::confirm(format!("Launch {only} to fix them?"))
+            let question = match kind {
+                LaunchKind::Fix => format!("Launch {only} to fix the issues above?"),
+                LaunchKind::Now => format!("Launch {only} now?"),
+            };
+            cliclack::confirm(question)
                 .initial_value(true)
                 .interact()
                 .ok()
@@ -50,8 +61,11 @@ fn choose_agent(agents: &[&'static str]) -> Option<&'static str> {
                 .map(|_| *only)
         }
         many => {
-            let mut select = cliclack::select("Launch an agent to fix the setup issues above?")
-                .item(None, "skip", "");
+            let prompt = match kind {
+                LaunchKind::Fix => "Launch an agent to fix the issues above?",
+                LaunchKind::Now => "Launch an agent now?",
+            };
+            let mut select = cliclack::select(prompt).item(None, "skip", "");
             for name in many {
                 select = select.item(Some(*name), *name, "");
             }
@@ -60,7 +74,7 @@ fn choose_agent(agents: &[&'static str]) -> Option<&'static str> {
     }
 }
 
-/// Seed an agent with the failing checks and the commands that repair them, so
+/// Seed an agent with the critical checks and the commands that repair them, so
 /// it can pick up the fix without the user restating anything.
 fn fix_prompt(issues: &[&doctor::Check]) -> String {
     let lines: Vec<String> = issues
@@ -83,30 +97,42 @@ fn fix_prompt(issues: &[&doctor::Check]) -> String {
     )
 }
 
-async fn launch_agent(cfg: &Config, name: &str, prompt: &str) -> Result<()> {
-    let args = [prompt.to_string()];
+async fn launch_agent(cfg: &Config, name: &str, args: &[String]) -> Result<()> {
     match name {
-        "claude" => harness::claude::run(cfg, &args).await,
+        "claude" => harness::claude::run(cfg, args).await,
         other => Err(Error::msg(format!("don't know how to launch {other}"))),
     }
 }
 
-/// Close setup by running `dense doctor`; if anything is amiss and an agent is
-/// installed, offer to launch one (seeded with the failing checks) to fix the
-/// wiring. Non-interactive runs only print the report.
-async fn offer_fix(cfg: &Config, interactive: bool) -> Result<()> {
+/// Close setup by running `dense doctor`. With critical wiring issues, offer to
+/// launch an installed agent (seeded with them) to fix; otherwise just offer to
+/// launch one now. Non-interactive runs only print the report.
+async fn offer_launch(cfg: &Config, interactive: bool) -> Result<()> {
     println!();
     let checks = doctor::diagnose(cfg).await;
     doctor::print_report(cfg, &checks);
-
-    let issues: Vec<&doctor::Check> = checks.iter().filter(|c| c.is_issue()).collect();
-    if issues.is_empty() || !interactive {
+    if !interactive {
         return Ok(());
     }
-    let Some(agent) = choose_agent(&available_agents(cfg)) else {
+    let agents = available_agents(cfg);
+    if agents.is_empty() {
+        return Ok(());
+    }
+
+    let critical: Vec<&doctor::Check> = checks.iter().filter(|c| c.is_critical()).collect();
+    let kind = if critical.is_empty() {
+        LaunchKind::Now
+    } else {
+        LaunchKind::Fix
+    };
+    let Some(agent) = choose_agent(&agents, kind) else {
         return Ok(());
     };
-    launch_agent(cfg, agent, &fix_prompt(&issues)).await
+    let args = match kind {
+        LaunchKind::Fix => vec![fix_prompt(&critical)],
+        LaunchKind::Now => Vec::new(),
+    };
+    launch_agent(cfg, agent, &args).await
 }
 
 /// Ask a yes/no question with a dim one-line explainer. Interactive: a

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -8,15 +8,105 @@ use std::io::IsTerminal;
 use std::path::Path;
 
 use crate::config::Config;
-use crate::{Result, env_file, persist, ui};
+use crate::error::Error;
+use crate::{Result, doctor, env_file, harness, persist, tool, ui};
+
+/// Coding agents `dense` can launch to repair a broken install. Only those with
+/// a harness run path belong here; setup offers the ones actually installed.
+const FIX_AGENTS: &[&str] = &["claude"];
 
 pub async fn run(cfg: &Config) -> Result<()> {
     let interactive = std::io::stdin().is_terminal();
     let res = wizard(cfg, interactive);
-    if res.is_err() && interactive {
-        let _ = cliclack::outro_cancel(ui::yellow("setup did not finish."));
+    if res.is_err() {
+        if interactive {
+            let _ = cliclack::outro_cancel(ui::yellow("setup did not finish."));
+        }
+        return res;
     }
-    res
+    offer_fix(cfg, interactive).await
+}
+
+fn available_agents(cfg: &Config) -> Vec<&'static str> {
+    FIX_AGENTS
+        .iter()
+        .copied()
+        .filter(|name| tool::resolve_real(cfg, name).is_ok())
+        .collect()
+}
+
+/// Ask which installed agent (if any) should fix the issues. One agent is a
+/// yes/no; several is a pick-or-skip select. `None` = leave it alone.
+fn choose_agent(agents: &[&'static str]) -> Option<&'static str> {
+    match agents {
+        [] => None,
+        [only] => {
+            let _ = cliclack::log::warning("dense found setup issues above.");
+            cliclack::confirm(format!("Launch {only} to fix them?"))
+                .initial_value(true)
+                .interact()
+                .ok()
+                .filter(|yes| *yes)
+                .map(|_| *only)
+        }
+        many => {
+            let mut select = cliclack::select("Launch an agent to fix the setup issues above?")
+                .item(None, "skip", "");
+            for name in many {
+                select = select.item(Some(*name), *name, "");
+            }
+            select.interact().ok().flatten()
+        }
+    }
+}
+
+/// Seed an agent with the failing checks and the commands that repair them, so
+/// it can pick up the fix without the user restating anything.
+fn fix_prompt(issues: &[&doctor::Check]) -> String {
+    let lines: Vec<String> = issues
+        .iter()
+        .map(|c| {
+            if c.detail.is_empty() {
+                format!("- {}", c.label)
+            } else {
+                format!("- {} ({})", c.label, c.detail)
+            }
+        })
+        .collect();
+    format!(
+        "My `dense` CLI install isn't fully wired. `dense doctor` reports these \
+         issues:\n{}\n\ndense routes Claude Code through the condense proxy. \
+         Relevant commands: `dense doctor` (re-check), `dense persist` (install \
+         PATH shims), `dense login` (authenticate). Please diagnose and fix the \
+         wiring, then run `dense doctor` to confirm everything passes.",
+        lines.join("\n")
+    )
+}
+
+async fn launch_agent(cfg: &Config, name: &str, prompt: &str) -> Result<()> {
+    let args = [prompt.to_string()];
+    match name {
+        "claude" => harness::claude::run(cfg, &args).await,
+        other => Err(Error::msg(format!("don't know how to launch {other}"))),
+    }
+}
+
+/// Close setup by running `dense doctor`; if anything is amiss and an agent is
+/// installed, offer to launch one (seeded with the failing checks) to fix the
+/// wiring. Non-interactive runs only print the report.
+async fn offer_fix(cfg: &Config, interactive: bool) -> Result<()> {
+    println!();
+    let checks = doctor::diagnose(cfg).await;
+    doctor::print_report(cfg, &checks);
+
+    let issues: Vec<&doctor::Check> = checks.iter().filter(|c| c.is_issue()).collect();
+    if issues.is_empty() || !interactive {
+        return Ok(());
+    }
+    let Some(agent) = choose_agent(&available_agents(cfg)) else {
+        return Ok(());
+    };
+    launch_agent(cfg, agent, &fix_prompt(&issues)).await
 }
 
 /// Ask a yes/no question with a dim one-line explainer. Interactive: a


### PR DESCRIPTION
Two independent improvements to the dense CLI, each its own commit.

## 1. Route `claude agents` dispatched sessions through condense

`claude agents` dispatches background sessions whose env is stripped of `ANTHROPIC_BASE_URL` / `ANTHROPIC_CUSTOM_HEADERS`, so they never reached the proxy. The agent view *does* thread a `--settings` block down to those sessions, and a settings `env` map is re-applied to `process.env` at startup — so the route is folded in there.

- New `Tool::rewrite_args` hook (default: argv unchanged), called in `launch`.
- `Claude`'s impl detects the `agents` subcommand and merges `ANTHROPIC_BASE_URL` + the condense headers into the `--settings` env block: reuses an existing inline-or-file `--settings` and preserves the user's own keys, or appends a fresh one.
- User OAuth/subscription auth is untouched — only the route rides in.

## 2. Post-install doctor + offer an agent to fix issues

The installer hands off to `dense setup`; that flow now closes by running the doctor checks and printing the report. When checks fail and a coding agent is installed, setup offers to launch one — seeded with the failing checks and the repair commands — to fix the wiring. One agent is a yes/no; several is a pick-or-skip select. Non-interactive runs only print the report.

- Refactored `doctor` into a structured `diagnose() -> Vec<Check>` plus `print_report`, shared by `dense doctor` and setup.
- No change to `install.sh` — it already ends with `exec dense setup`, so the installer's final step now runs doctor + the fix offer.

## Checks

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` (29 passed) all green.