### PR TITLE
feat(codex): CONDENSE_CODEX_WEBSOCKET — opt into the Responses WebSocket transport

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,8 @@ pub struct Config {
     /// Whether the api gates auth — `$CONDENSE_AUTH_REQUIRED` if set, else the
     /// profile's declared value (`None` = unknown).
     pub auth_required: Option<bool>,
+    /// `$CONDENSE_CODEX_WEBSOCKET` — codex Responses transport; WS unless set to `0` (→ HTTP).
+    pub codex_websocket: bool,
     config_dir: PathBuf,
     data_dir: PathBuf,
     home: PathBuf,
@@ -174,6 +176,7 @@ impl Config {
             api_base_url,
             api_host,
             auth_required: env_auth_required().or(profile.auth_required),
+            codex_websocket: env_flag_or("CONDENSE_CODEX_WEBSOCKET", true),
             config_dir,
             data_dir,
             home,
@@ -266,6 +269,11 @@ fn env_auth_required() -> Option<bool> {
 /// Whether `key` is set to a truthy value (`1`/`true`).
 fn env_flag(key: &str) -> bool {
     std::env::var(key).ok().is_some_and(|v| env_truthy(&v))
+}
+
+/// Whether `key` is truthy, or `default` when unset.
+fn env_flag_or(key: &str, default: bool) -> bool {
+    std::env::var(key).ok().map_or(default, |v| env_truthy(&v))
 }
 
 fn env_truthy(v: &str) -> bool {

--- a/src/harness/codex.rs
+++ b/src/harness/codex.rs
@@ -9,7 +9,9 @@ use crate::harness::{self, ProxyTarget, Tool};
 // `-c` overlays merge (can't delete) a stale block's keys, so we own a private id.
 const PROVIDER_ID: &str = "condense_cli";
 
-pub struct Codex;
+pub struct Codex {
+    websocket: bool,
+}
 
 impl Tool<OpenAi> for Codex {
     /// Codex has no single custom-headers env var, so the provider is defined
@@ -33,13 +35,19 @@ impl Tool<OpenAi> for Codex {
         // login (ChatGPT OAuth or an sk- key) as the bearer + chatgpt-account-id.
         // The proxy forwards that to OpenAI (api.openai.com or, for OAuth, the
         // codex backend); condense identity rides in the x-condense-* headers.
-        let overrides = [
+        // Pin the transport so condense decides it, not codex's per-provider
+        // default. WS by default (codex's native mode); CONDENSE_CODEX_WEBSOCKET=0 → HTTP.
+        let overrides = vec![
             format!(r#"model_provider="{PROVIDER_ID}""#),
             format!(r#"model_providers.{PROVIDER_ID}.name="condense""#),
             format!(r#"model_providers.{PROVIDER_ID}.base_url="{base_url}""#),
             format!(r#"model_providers.{PROVIDER_ID}.wire_api="responses""#),
             format!("model_providers.{PROVIDER_ID}.requires_openai_auth=true"),
             format!("model_providers.{PROVIDER_ID}.env_http_headers={env_http_headers}"),
+            format!(
+                "model_providers.{PROVIDER_ID}.supports_websockets={}",
+                self.websocket
+            ),
         ];
         for o in overrides {
             cmd.arg("-c").arg(o);
@@ -58,7 +66,15 @@ impl Tool<OpenAi> for Codex {
 /// `dense codex` — Codex through the OpenAI Responses proxy. The dialect is the
 /// concrete `OpenAi`, so no proxy flag is threaded through the run path.
 pub async fn run(cfg: &Config, args: &[String]) -> Result<()> {
-    harness::launch(cfg, Codex, OpenAi, args).await
+    harness::launch(
+        cfg,
+        Codex {
+            websocket: cfg.codex_websocket,
+        },
+        OpenAi,
+        args,
+    )
+    .await
 }
 
 /// Per-header env var name holding the secret value; the `env_http_headers` map
@@ -99,7 +115,7 @@ mod tests {
             )],
         };
         let mut cmd = tokio::process::Command::new("codex");
-        Codex.apply(&mut cmd, &target);
+        Codex { websocket: true }.apply(&mut cmd, &target);
 
         let std_cmd = cmd.as_std();
         let args: Vec<String> = std_cmd
@@ -116,8 +132,8 @@ mod tests {
         assert!(argv.contains(r#"model_provider="condense_cli""#));
         assert!(argv.contains(r#"model_providers.condense_cli.wire_api="responses""#));
         assert!(argv.contains("model_providers.condense_cli.requires_openai_auth=true"));
-        // The header value rides in an env var referenced by env_http_headers —
-        // never in argv.
+        // Transport pinned explicitly; WS is the default.
+        assert!(argv.contains("model_providers.condense_cli.supports_websockets=true"));
         assert!(argv.contains("CONDENSE_HDR_X_CONDENSE_AUTH_TOKEN"));
         assert!(!argv.contains("secret-token"));
 
@@ -125,5 +141,22 @@ mod tests {
             k == "CONDENSE_HDR_X_CONDENSE_AUTH_TOKEN" && v == Some("secret-token".as_ref())
         });
         assert!(has_secret_env);
+    }
+
+    #[test]
+    fn apply_pins_http_when_websockets_disabled() {
+        let target = ProxyTarget {
+            base_url: "https://api.condense.chat/openai".to_string(),
+            headers: vec![],
+        };
+        let mut cmd = tokio::process::Command::new("codex");
+        Codex { websocket: false }.apply(&mut cmd, &target);
+        let argv: String = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(argv.contains("model_providers.condense_cli.supports_websockets=false"));
     }
 }


### PR DESCRIPTION
## What
`dense codex` pins codex's Responses transport on its injected `condense_cli` provider — `supports_websockets=true` WS by default

## Why this shape
Codex's WS transport is a per-provider flag (`supports_websockets`), not a CLI flag — and the harness injects its own provider, so left unset the wire is decided by codex's evolving defaults, not condense. Pinning it explicitly gives condense deterministic control.

## Scope / safety
- `config.rs +3`, `codex.rs` small; no new deps, no filesystem reads.
- Default path byte-identical except the explicit `supports_websockets=false`; tests assert both pins.
- `cargo fmt` / `clippy -D warnings` / `cargo test` green.
