### PR TITLE
fix(claude): force Tool Search off behind an upstream override

### DIFF
--- a/src/harness.rs
+++ b/src/harness.rs
@@ -41,6 +41,9 @@ pub struct Target {
     pub base_url: String,
     pub headers: Vec<(String, String)>,
     pub route: &'static str,
+    /// `$CONDENSE_UPSTREAM_URL` — set when the proxy forwards to a
+    /// non-default upstream (also sent as `x-condense-upstream-url`).
+    pub upstream: Option<String>,
 }
 
 /// Append the `/v1` API segment to a dialect base, tolerating a trailing slash.
@@ -68,6 +71,7 @@ pub async fn launch<T: Tool>(cfg: &Config, tool: T, args: &[String]) -> Result<(
             route: d.route(),
             base_url: d.base_url(cfg),
             headers: headers.clone(),
+            upstream: cfg.upstream().map(str::to_string),
         })
         .collect();
 

--- a/src/harness/claude.rs
+++ b/src/harness/claude.rs
@@ -23,12 +23,22 @@ impl Tool for Claude {
             // Pin the auto-compact window to the full 1M. Read via parseInt, so
             // "1m" would parse to 1 — pass the literal token count. Overrides a
             // lower settings/experiment/model-default so we don't compact early.
-            .env("CLAUDE_CODE_AUTO_COMPACT_WINDOW", "1000000")
-            // Force Tool Search on so MCP tool defs stay deferred out of context
-            // (lazy-loaded via tool_reference) instead of loading eagerly every
-            // turn. Claude Code disables it behind a non-first-party base URL;
-            // condense forwards tool_reference blocks verbatim, so this is safe.
-            .env("ENABLE_TOOL_SEARCH", "true");
+            .env("CLAUDE_CODE_AUTO_COMPACT_WINDOW", "1000000");
+        // Tool Search (deferred MCP tool defs via tool_reference) is an
+        // Anthropic feature; behind an upstream override, respect how that
+        // provider already works. Off must be explicit: the first-party
+        // assert above makes Claude Code enable it by itself. A caller's
+        // own value wins.
+        if std::env::var_os("ENABLE_TOOL_SEARCH").is_none() {
+            cmd.env(
+                "ENABLE_TOOL_SEARCH",
+                if target.upstream.is_some() {
+                    "false"
+                } else {
+                    "true"
+                },
+            );
+        }
     }
 
     fn binary(&self) -> &str {
@@ -92,5 +102,32 @@ mod tests {
     fn merge_without_existing_is_just_ours() {
         let ours = vec![("x-condense-user-id".to_string(), "u".to_string())];
         assert_eq!(merge_headers(None, &ours), "x-condense-user-id: u");
+    }
+
+    #[test]
+    fn tool_search_follows_upstream_override() {
+        assert_eq!(tool_search_env(&target(None)), Some("true".to_string()));
+        assert_eq!(
+            tool_search_env(&target(Some("https://router.example"))),
+            Some("false".to_string())
+        );
+    }
+
+    fn target(upstream: Option<&str>) -> Target {
+        Target {
+            route: "anthropic",
+            base_url: "https://api.condense.chat/anthropic".to_string(),
+            headers: vec![],
+            upstream: upstream.map(str::to_string),
+        }
+    }
+
+    fn tool_search_env(target: &Target) -> Option<String> {
+        let mut cmd = tokio::process::Command::new("claude");
+        Claude.apply(&mut cmd, std::slice::from_ref(target));
+        cmd.as_std()
+            .get_envs()
+            .find(|(name, _)| *name == "ENABLE_TOOL_SEARCH")
+            .and_then(|(_, value)| value.map(|v| v.to_string_lossy().into_owned()))
     }
 }

--- a/src/harness/codex.rs
+++ b/src/harness/codex.rs
@@ -117,6 +117,7 @@ mod tests {
                 "x-condense-auth-token".to_string(),
                 "secret-token".to_string(),
             )],
+            upstream: None,
         };
         let mut cmd = tokio::process::Command::new("codex");
         Codex { websocket: true }.apply(&mut cmd, &[target]);
@@ -153,6 +154,7 @@ mod tests {
             route: "openai",
             base_url: "https://api.condense.chat/openai".to_string(),
             headers: vec![],
+            upstream: None,
         };
         let mut cmd = tokio::process::Command::new("codex");
         Codex { websocket: false }.apply(&mut cmd, &[target]);

--- a/src/harness/opencode.rs
+++ b/src/harness/opencode.rs
@@ -287,11 +287,13 @@ mod tests {
                 route: "anthropic",
                 base_url: "https://api.example.com/anthropic".into(),
                 headers: vec![("x-condense-session-id".into(), "s".into())],
+                upstream: None,
             },
             Target {
                 route: "openai",
                 base_url: "https://api.example.com/openai".into(),
                 headers: vec![("x-condense-session-id".into(), "s".into())],
+                upstream: None,
             },
         ]
     }


### PR DESCRIPTION
Tool Search is an Anthropic feature: it defers MCP tool defs out of context, lazy-loaded via `tool_reference` blocks. Behind an upstream override (`CONDENSE_UPSTREAM_URL`) we should respect how that provider already works instead of assuming it accepts `tool_reference` — Requesty, for one, 400s on them with an unknown-unmarshal error (4 bench trials died on it).

Since `dense claude` asserts `_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1`, Claude Code enables Tool Search on its own — so behind an override the off must be explicit:

- `ENABLE_TOOL_SEARCH=false` when an upstream override is configured, `true` otherwise
- a caller's own `ENABLE_TOOL_SEARCH` is never clobbered
- the override rides `Target.upstream`, resolved from `Config` at the one construction site

🤖 Generated with [Claude Code](https://claude.com/claude-code)