### PR TITLE
fix(claude): don't assert first-party behind an upstream override

### DIFF
--- a/src/harness/claude.rs
+++ b/src/harness/claude.rs
@@ -20,35 +20,23 @@ impl Tool for Claude {
             // "1m" would parse to 1 — pass the literal token count. Overrides a
             // lower settings/experiment/model-default so we don't compact early.
             .env("CLAUDE_CODE_AUTO_COMPACT_WINDOW", "1000000");
-        // Claude Code disables the 1M context window when the base URL is not
-        // api.anthropic.com, silently falling back to 200K (compacts ~140K).
-        // Assert first-party so the 1M window stays on through us — but only
-        // when we forward to Anthropic. Behind an upstream override the base
-        // URL genuinely is not first-party, and asserting it makes Claude Code
-        // prepend an `x-anthropic-billing-header:` system block whose `cch=`
-        // token is a per-request nonce: Anthropic's edge lifts it back out, a
-        // gateway reads it as prompt text that differs every turn, and the
-        // whole prefix cache is forfeit (measured 0% cache read on
-        // gpt-5.6-luna and grok via Requesty, restored to ~99.5% without it).
-        // That provider's own window governs there anyway.
-        if target.upstream.is_none() {
-            cmd.env("_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL", "1");
-        }
-        // Tool Search (deferred MCP tool defs via tool_reference) is an
-        // Anthropic feature; behind an upstream override, respect how that
-        // provider already works. Off must be explicit: the first-party
-        // assert above makes Claude Code enable it by itself. A caller's
-        // own value wins.
-        if std::env::var_os("ENABLE_TOOL_SEARCH").is_none() {
-            cmd.env(
-                "ENABLE_TOOL_SEARCH",
-                if target.upstream.is_some() {
-                    "false"
-                } else {
-                    "true"
-                },
-            );
-        }
+        // Anthropic-only knobs, both keyed on the same fact. The first-party
+        // assert keeps the 1M window on (Claude Code silently drops to 200K off
+        // api.anthropic.com) but also makes it prepend an
+        // `x-anthropic-billing-header:` system block whose `cch=` is a
+        // per-request nonce: Anthropic's edge lifts it back out, a gateway reads
+        // it as prompt text and forfeits the whole prefix cache (0% cache read
+        // on gpt-5.6-luna and grok via Requesty, ~99.5% without it). Tool Search
+        // is likewise Anthropic-only, and off must be explicit since a
+        // first-party Claude Code turns it on by itself.
+        anthropic_only(
+            cmd,
+            target,
+            "_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL",
+            "1",
+            None,
+        );
+        anthropic_only(cmd, target, "ENABLE_TOOL_SEARCH", "true", Some("false"));
     }
 
     fn binary(&self) -> &str {
@@ -63,6 +51,29 @@ impl Tool for Claude {
 /// `dense claude` — Claude Code through the Anthropic proxy.
 pub async fn run(cfg: &Config, args: &[String]) -> Result<()> {
     harness::launch(cfg, Claude, args).await
+}
+
+/// An Anthropic-only knob: `on` when we forward to Anthropic itself, `off`
+/// behind an upstream override where that provider's own behaviour governs
+/// (`None` leaves it unset). A caller's own value always wins.
+fn anthropic_only(
+    cmd: &mut tokio::process::Command,
+    target: &Target,
+    key: &str,
+    on: &str,
+    off: Option<&str>,
+) {
+    if std::env::var_os(key).is_some() {
+        return;
+    }
+    let value = if target.upstream.is_some() {
+        off
+    } else {
+        Some(on)
+    };
+    if let Some(value) = value {
+        cmd.env(key, value);
+    }
 }
 
 fn custom_headers(headers: &[(String, String)]) -> String {

--- a/src/harness/claude.rs
+++ b/src/harness/claude.rs
@@ -16,14 +16,24 @@ impl Tool for Claude {
         let target = &targets[0];
         cmd.env("ANTHROPIC_BASE_URL", &target.base_url)
             .env("ANTHROPIC_CUSTOM_HEADERS", custom_headers(&target.headers))
-            // Claude Code disables the 1M context window when the base URL is
-            // not api.anthropic.com, silently falling back to 200K (compacts
-            // ~140K). Assert first-party so the 1M window stays on through us.
-            .env("_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL", "1")
             // Pin the auto-compact window to the full 1M. Read via parseInt, so
             // "1m" would parse to 1 — pass the literal token count. Overrides a
             // lower settings/experiment/model-default so we don't compact early.
             .env("CLAUDE_CODE_AUTO_COMPACT_WINDOW", "1000000");
+        // Claude Code disables the 1M context window when the base URL is not
+        // api.anthropic.com, silently falling back to 200K (compacts ~140K).
+        // Assert first-party so the 1M window stays on through us — but only
+        // when we forward to Anthropic. Behind an upstream override the base
+        // URL genuinely is not first-party, and asserting it makes Claude Code
+        // prepend an `x-anthropic-billing-header:` system block whose `cch=`
+        // token is a per-request nonce: Anthropic's edge lifts it back out, a
+        // gateway reads it as prompt text that differs every turn, and the
+        // whole prefix cache is forfeit (measured 0% cache read on
+        // gpt-5.6-luna and grok via Requesty, restored to ~99.5% without it).
+        // That provider's own window governs there anyway.
+        if target.upstream.is_none() {
+            cmd.env("_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL", "1");
+        }
         // Tool Search (deferred MCP tool defs via tool_reference) is an
         // Anthropic feature; behind an upstream override, respect how that
         // provider already works. Off must be explicit: the first-party
@@ -105,6 +115,21 @@ mod tests {
     }
 
     #[test]
+    fn first_party_assert_is_dropped_behind_an_upstream_override() {
+        const KEY: &str = "_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL";
+        assert_eq!(env_of(&target(None), KEY), Some("1".to_string()));
+        assert_eq!(env_of(&target(Some("https://router.example")), KEY), None);
+    }
+
+    #[test]
+    fn auto_compact_window_is_pinned_either_way() {
+        const KEY: &str = "CLAUDE_CODE_AUTO_COMPACT_WINDOW";
+        for t in [target(None), target(Some("https://router.example"))] {
+            assert_eq!(env_of(&t, KEY), Some("1000000".to_string()));
+        }
+    }
+
+    #[test]
     fn tool_search_follows_upstream_override() {
         assert_eq!(tool_search_env(&target(None)), Some("true".to_string()));
         assert_eq!(
@@ -122,12 +147,16 @@ mod tests {
         }
     }
 
-    fn tool_search_env(target: &Target) -> Option<String> {
+    fn env_of(target: &Target, name: &str) -> Option<String> {
         let mut cmd = tokio::process::Command::new("claude");
         Claude.apply(&mut cmd, std::slice::from_ref(target));
         cmd.as_std()
             .get_envs()
-            .find(|(name, _)| *name == "ENABLE_TOOL_SEARCH")
+            .find(|(key, _)| *key == name)
             .and_then(|(_, value)| value.map(|v| v.to_string_lossy().into_owned()))
+    }
+
+    fn tool_search_env(target: &Target) -> Option<String> {
+        env_of(target, "ENABLE_TOOL_SEARCH")
     }
 }


### PR DESCRIPTION
## Problem

Asserting `_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1` makes Claude Code prepend a system block at index 0:

```
x-anthropic-billing-header: cc_version=2.1.237.340; cc_entrypoint=sdk-cli; cch=3708d; cc_prompt_id=…;
```

`cch=` is a **per-request nonce** (`3708d`, `7e431`, `216aa`, `2a7db`, …). Every other system block is byte-stable across a session.

Anthropic's own edge lifts that block back out. A gateway that caches by automatic prefix match does not — it reads it as prompt text. So the first ~136 characters of every request differ, longest-prefix matching returns nothing, and the entire cache is forfeit on every turn.

## Measured

Same prompt, same gateway, same key, same proxy — only this env var differs:

| client | read% |
|---|---|
| stock `claude` (no assert) | 99.8% |
| `dense` (assert set) | **0.0%** on all 11 turns |
| stock `claude` + `_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1` | **0.0%** on all 11 turns |
| stock `claude` + `ENABLE_TOOL_SEARCH=false` (control) | 99.8% |

`inp` stays pinned at full context on the failing arms instead of collapsing to 40–180.

Observed on `openai/gpt-5.6-luna` and grok via Requesty. Cost impact was roughly 1.4–1.8x vanilla for identical work.

## Fix

Gate the assert on `target.upstream.is_none()`. Behind an upstream override the base URL genuinely isn't first-party, and that provider's own context window governs, so the 1M assert buys nothing there.

`CLAUDE_CODE_AUTO_COMPACT_WINDOW` stays pinned unconditionally — that's what actually holds off early compaction.

The second commit unifies this with the existing Tool Search gate. Both are the same decision — an Anthropic-only knob, on when we forward to Anthropic and off behind an upstream override — and were stated twice, inconsistently: only Tool Search let a caller's own value win. `anthropic_only()` now expresses it once, which also makes the first-party assert overridable for anyone who wants the 1M window behind a gateway and knows the trade-off.

## Tests

- `first_party_assert_is_dropped_behind_an_upstream_override`
- `auto_compact_window_is_pinned_either_way`
- existing `tool_search_follows_upstream_override` unchanged, now sharing the `env_of` helper

`cargo fmt`, `cargo clippy --all-targets`, `cargo test` all clean (34 + 4 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)